### PR TITLE
Update ESLint config to use @stylistic/eslint-plugin v5.2.3

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,16 +1,14 @@
 import js from "@eslint/js"
-// https://www.npmjs.com/package/eslint-plugin-jsdoc
 import jsdoc from "eslint-plugin-jsdoc";
-import stylisticJs from "@stylistic/eslint-plugin-js"
-import plugin from "@stylistic/eslint-plugin-js";
+import stylistic from "@stylistic/eslint-plugin"
 
 export default [
   js.configs.recommended,
   jsdoc.configs['flat/recommended'], {
-    name: "gesslar/bedoc/ignores",
-    ignores: ["docs/", "_docs/", "TODO/", "examples/source/"],
+    name: "gesslar/aunty/ignores",
+    ignores: [],
   }, {
-    name: "gesslar/bedoc/languageOptions",
+    name: "gesslar/aunty/languageOptions",
     languageOptions: {
       ecmaVersion: "latest",
       sourceType: "module",
@@ -21,19 +19,19 @@ export default [
     },
   },
   {
-    name: "gesslar/bedoc/lints",
-    files: ["src/**/*.{mjs,cjs,js}", "examples/**/*.js"],
+    name: "gesslar/aunty/lints-js",
+    files: ["src/**/*.{mjs,cjs,js}"],
     plugins: {
-      "@stylistic/js": stylisticJs,
-      jsdoc: jsdoc,
-      plugin,
+      "@stylistic": stylistic,
     },
     rules: {
-      "@stylistic/js/arrow-parens": ["error", "as-needed"],
-      "@stylistic/js/arrow-spacing": ["error", { before: true, after: true }],
+      "@stylistic/arrow-parens": ["error", "as-needed"],
+      "@stylistic/arrow-spacing": ["error", { before: true, after: true }],
       // Ensure control statements and their bodies are not on the same line
-      "@stylistic/js/brace-style": ["error", "1tbs", {allowSingleLine: false}],
-      "@stylistic/js/padding-line-between-statements": [
+      "@stylistic/brace-style": ["error", "1tbs", {allowSingleLine: false}],
+      // Same, but for non bracy ones.
+      "@stylistic/nonblock-statement-body-position": ["error", "below"],
+      "@stylistic/padding-line-between-statements": [
         "error",
         {blankLine: "always", prev: "if", next: "*"},
         {blankLine: "always", prev: "for", next: "*"},
@@ -41,12 +39,12 @@ export default [
         {blankLine: "always", prev: "do", next: "*"},
         {blankLine: "always", prev: "switch", next: "*"}
       ],
-      "@stylistic/js/eol-last": ["error", "always"],
-      "@stylistic/js/indent": ["error", 2, {
+      "@stylistic/eol-last": ["error", "always"],
+      "@stylistic/indent": ["error", 2, {
         SwitchCase: 1 // Indents `case` statements one level deeper than `switch`
       }],
-      "@stylistic/js/key-spacing": ["error", { beforeColon: false, afterColon: true }],
-      "@stylistic/js/keyword-spacing": ["error", {
+      "@stylistic/key-spacing": ["error", { beforeColon: false, afterColon: true }],
+      "@stylistic/keyword-spacing": ["error", {
         before: false,
         after: true,
         overrides: {
@@ -77,7 +75,7 @@ export default [
           finally: { before: true, after: true },
         }
       }],
-      "@stylistic/js/max-len": ["warn", {
+      "@stylistic/max-len": ["warn", {
         code: 80,
         ignoreComments: true,
         ignoreUrls: true,
@@ -86,19 +84,19 @@ export default [
         ignoreRegExpLiterals: true,
         tabWidth: 2
       }],
-      "@stylistic/js/no-tabs": "error",
-      "@stylistic/js/no-trailing-spaces": ["error"],
-      "@stylistic/js/object-curly-spacing": ["error", "never", {
+      "@stylistic/no-tabs": "error",
+      "@stylistic/no-trailing-spaces": ["error"],
+      "@stylistic/object-curly-spacing": ["error", "never", {
         objectsInObjects: false,
         arraysInObjects: false
       }],
-      "@stylistic/js/quotes": ["error", "double", {
+      "@stylistic/quotes": ["error", "double", {
         avoidEscape: true,
-        allowTemplateLiterals: true
+        allowTemplateLiterals: "always"
       }],
-      "@stylistic/js/semi": ["error", "never"],
-      "@stylistic/js/space-before-function-paren": ["error", "never"],
-      "@stylistic/js/yield-star-spacing": ["error", { before: true, after: false }],
+      "@stylistic/semi": ["error", "never"],
+      "@stylistic/space-before-function-paren": ["error", "never"],
+      "@stylistic/yield-star-spacing": ["error", { before: true, after: false }],
       "constructor-super": "error",
       "no-unexpected-multiline": "error",
       "no-unused-vars": ["error", {
@@ -109,8 +107,15 @@ export default [
         varsIgnorePattern: "^_+"
       }],
       "no-useless-assignment": "error",
-
-      // JSDoc
+    }
+  },
+  {
+    name: "gesslar/aunty/lints-jsdoc",
+    files: ["src/**/*.{mjs,cjs,js}"],
+    plugins: {
+      jsdoc,
+    },
+    rules: {
       "jsdoc/require-description": "error",
       "jsdoc/tag-lines": ["error", "any", {"startLines":1}]
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "aunty": "src/build.js"
       },
       "devDependencies": {
-        "@stylistic/eslint-plugin-js": "^4.4.0",
+        "@stylistic/eslint-plugin": "^5.2.3",
         "@typescript-eslint/eslint-plugin": "^8.33.0",
         "@typescript-eslint/parser": "^8.33.0",
         "eslint": "^9.28.0",
@@ -334,20 +334,36 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/@stylistic/eslint-plugin-js": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin-js/-/eslint-plugin-js-4.4.1.tgz",
-      "integrity": "sha512-eLisyHvx7Sel8vcFZOEwDEBGmYsYM1SqDn81BWgmbqEXfXRf8oe6Rwp+ryM/8odNjlxtaaxp0Ihmt86CnLAxKg==",
+    "node_modules/@stylistic/eslint-plugin": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin/-/eslint-plugin-5.2.3.tgz",
+      "integrity": "sha512-oY7GVkJGVMI5benlBDCaRrSC1qPasafyv5dOBLLv5MTilMGnErKhO6ziEfodDDIZbo5QxPUNW360VudJOFODMw==",
       "dev": true,
       "dependencies": {
-        "eslint-visitor-keys": "^4.2.0",
-        "espree": "^10.3.0"
+        "@eslint-community/eslint-utils": "^4.7.0",
+        "@typescript-eslint/types": "^8.38.0",
+        "eslint-visitor-keys": "^4.2.1",
+        "espree": "^10.4.0",
+        "estraverse": "^5.3.0",
+        "picomatch": "^4.0.3"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "peerDependencies": {
         "eslint": ">=9.0.0"
+      }
+    },
+    "node_modules/@stylistic/eslint-plugin/node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/@types/estree": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gesslar/aunty",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "displayName": "Aunty Rose",
   "description": "Make gorgeous themes that speak as boldly as you do.",
   "publisher": "gesslar",
@@ -47,7 +47,7 @@
     "yaml": "^2.8.1"
   },
   "devDependencies": {
-    "@stylistic/eslint-plugin-js": "^4.4.0",
+    "@stylistic/eslint-plugin": "^5.2.3",
     "@typescript-eslint/eslint-plugin": "^8.33.0",
     "@typescript-eslint/parser": "^8.33.0",
     "eslint": "^9.28.0",

--- a/src/build.js
+++ b/src/build.js
@@ -357,7 +357,8 @@ function hashOf(s) {
 async function time(label, fn, profile) {
   const t0 = performance.now()
   const res = await fn()
-  if(profile) info(`${label}: ${(performance.now() - t0).toFixed(1)}ms`)
+  if(profile)
+    info(`${label}: ${(performance.now() - t0).toFixed(1)}ms`)
 
   return res
 }

--- a/src/components/Colour.js
+++ b/src/components/Colour.js
@@ -21,7 +21,8 @@ const asColor = s => {
     throw new Error("asColor(): received null/undefined")
 
   const k = String(s).trim()
-  if(!k) throw new Error("asColor(): received empty string")
+  if(!k)
+    throw new Error("asColor(): received empty string")
 
   let v = _colorCache.get(k)
   if(!v) {
@@ -253,7 +254,8 @@ export default class Colour {
 
     // memoize by raw inputs (strings) + normalized ratio
     const key = mixKey(colorA, colorB, t)
-    if(_mixCache.has(key)) return _mixCache.get(key)
+    if(_mixCache.has(key))
+      return _mixCache.get(key)
 
     const c1 = asColor(colorA)
     const c2 = asColor(colorB)

--- a/src/components/DataUtil.js
+++ b/src/components/DataUtil.js
@@ -139,7 +139,8 @@ function arrayIntersection(arr1, arr2) {
  */
 function arrayPad(arr, length, value, position = 0) {
   const diff = length - arr.length
-  if(diff <= 0) return arr
+  if(diff <= 0)
+    return arr
 
   const padding = Array(diff).fill(value)
 
@@ -149,7 +150,8 @@ function arrayPad(arr, length, value, position = 0) {
   else if(position === -1)
     // append
     return arr.concat(padding) // somewhere in the middle - THAT IS ILLEGAL
-  else throw new SyntaxError("Invalid position")
+  else
+    throw new SyntaxError("Invalid position")
 }
 
 /**


### PR DESCRIPTION
# Update ESLint Configuration and Fix Linting Issues

This PR updates the ESLint configuration to use the newer `@stylistic/eslint-plugin` package instead of the deprecated `@stylistic/eslint-plugin-js`. The changes include:

1. Replaced `@stylistic/eslint-plugin-js` with `@stylistic/eslint-plugin` (v5.2.3)
2. Updated all rule references from `@stylistic/js/rule-name` to `@stylistic/rule-name`
3. Added a new rule `@stylistic/nonblock-statement-body-position` to enforce consistent positioning
4. Split linting configurations into separate sections for JavaScript and JSDoc
5. Updated the project name references from "bedoc" to "aunty" in configuration sections
6. Removed unnecessary ignores for non-existent directories
7. Fixed code formatting in several files to comply with the updated linting rules
8. Bumped package version from 0.0.7 to 0.0.8

The PR also applies the updated linting rules to fix formatting issues in several source files, particularly around conditional statements that now require their bodies to be on separate lines.