### PR TITLE
Fix file reloading in build.js and bump version to 0.0.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gesslar/aunty",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "displayName": "Aunty Rose",
   "description": "Make gorgeous themes that speak as boldly as you do.",
   "publisher": "gesslar",

--- a/src/build.js
+++ b/src/build.js
@@ -261,16 +261,11 @@ async function processTheme({input, cwd, options}) {
             ])
 
             if(changed === bundle.file.path) {
-              const tempBundle = await loadThemeAsBundle(bundle.file)
+              const {cost: reloadCost, result: tempBundle} =
+                await time(async() => loadThemeAsBundle(bundle.file))
+              const reloadedBytes = await File.fileSize(bundle.file)
+
               bundle.source = tempBundle.source
-
-              const reloadedBytes = await File.fileSize(bundle.file.path)
-
-              statusMessage([
-              const {cost: reloadCost, result: tempBundle} = await time(async () => loadThemeAsBundle(bundle.file))
-              bundle.source = tempBundle.source
-
-              const reloadedBytes = await File.fileSize(file)
 
               statusMessage([
                 ["success", rightAlignText(`${reloadCost.toLocaleString()}ms`, 9)],


### PR DESCRIPTION
# Bump version to 0.0.10 and fix file reloading in build process

This PR:
- Increments the package version from 0.0.9 to 0.0.10
- Fixes a bug in the theme file reloading process:
  - Removes duplicate code for reloading theme bundles
  - Ensures proper file path reference when checking file size
  - Improves the timing measurement for the reload operation

The changes ensure that when a theme file changes, it's properly reloaded and its size is correctly measured.