### PR TITLE
Fix watch mode status message display and bump version to 0.0.12

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gesslar/aunty",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "displayName": "Aunty Rose",
   "description": "Make gorgeous themes that speak as boldly as you do.",
   "publisher": "gesslar",

--- a/src/build.js
+++ b/src/build.js
@@ -86,11 +86,13 @@ void (async function main() {
     const options = program.opts()
     const inputArgs = program.processedArgs[0]
 
-    statusMessage([
-      ["info", "WATCH MODE"],
-      "F5=recompile, q=quit"
-    ], options)
-    info("")
+    if(options.watch) {
+      statusMessage([
+        ["info", "WATCH MODE"],
+        "F5=recompile, q=quit"
+      ], options)
+      info("")
+    }
 
     await Promise.allSettled(
       inputArgs.map(input => processTheme({input, cwd, options}))


### PR DESCRIPTION
# Fix watch mode status message display

This PR fixes an issue where the "WATCH MODE" status message was being displayed even when the `--watch` flag was not set. Now, the status message only appears when the application is actually running in watch mode.