### PR TITLE
Add VSCode launch configurations for debugging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ node_modules/
 /output.txt
 dist/
 examples/output
+!.vscode/launch.json

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,95 @@
+// A launch configuration that launches the extension inside a new window
+// Use IntelliSense to learn about possible attributes.
+// Hover to view descriptions of existing attributes.
+// For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Extension",
+      "type": "extensionHost",
+      "request": "launch",
+      "runtimeExecutable": "${execPath}",
+      "args": [
+        "--extensionDevelopmentPath=${workspaceFolder}"
+      ]
+    },
+    {
+      "name": "Build",
+      "type": "node",
+      "request": "launch",
+      "runtimeExecutable": "npm",
+      "runtimeArgs": [
+        "run-script",
+        "build"
+      ],
+      "cwd": "${workspaceFolder}",
+      "console": "integratedTerminal"
+    },
+    {
+      "name": "Simple (JSON5)",
+      "type": "node",
+      "request": "launch",
+      "runtimeExecutable": "npm",
+      "runtimeArgs": [
+        "run-script",
+        "exec",
+        "--",
+        "--output-dir",
+        "./examples/output",
+        "./examples/simple/midnight-ocean.json5"
+      ],
+      "cwd": "${workspaceFolder}",
+      "console": "integratedTerminal"
+    },
+    {
+      "name": "Simple (YAML)",
+      "type": "node",
+      "request": "launch",
+      "runtimeExecutable": "npm",
+      "runtimeArgs": [
+        "run-script",
+        "exec",
+        "--",
+        "--output-dir",
+        "./examples/output",
+        "./examples/simple/midnight-ocean.yaml"
+      ],
+      "cwd": "${workspaceFolder}",
+      "console": "integratedTerminal"
+    },
+    {
+      "name": "Advanced (YAML)",
+      "type": "node",
+      "request": "launch",
+      "runtimeExecutable": "npm",
+      "runtimeArgs": [
+        "run-script",
+        "exec",
+        "--",
+        "--output-dir",
+        "./examples/output",
+        "./examples/advanced/src/blackboard.yaml"
+      ],
+      "cwd": "${workspaceFolder}",
+      "console": "integratedTerminal"
+    },
+    {
+      "name": "Advanced (YAML) (watch)",
+      "type": "node",
+      "request": "launch",
+      "runtimeExecutable": "npm",
+      "runtimeArgs": [
+        "run-script",
+        "exec",
+        "--",
+        "--watch",
+        "--output-dir",
+        "./examples/output",
+        "./examples/advanced/src/blackboard.yaml"
+      ],
+      "cwd": "${workspaceFolder}",
+      "console": "integratedTerminal"
+    },
+  ]
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -90,6 +90,6 @@
       ],
       "cwd": "${workspaceFolder}",
       "console": "integratedTerminal"
-    },
+    }
   ]
 }


### PR DESCRIPTION
# Add VS Code launch configurations for development

This PR adds a `.vscode/launch.json` file with several debug configurations to improve the development experience:

- **Extension**: Launches the extension in a new VS Code window
- **Build**: Runs the build script
- **Simple (JSON5)**: Executes the tool with a JSON5 example file
- **Simple (YAML)**: Executes the tool with a YAML example file
- **Advanced (YAML)**: Executes the tool with an advanced YAML example
- **Advanced (YAML) (watch)**: Same as above but with watch mode enabled

The PR also updates `.gitignore` to explicitly include the launch.json file while keeping other VS Code settings ignored.