### PR TITLE
Update VSCode launch configurations and bump version to 0.0.17

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -6,27 +6,6 @@
   "version": "0.2.0",
   "configurations": [
     {
-      "name": "Extension",
-      "type": "extensionHost",
-      "request": "launch",
-      "runtimeExecutable": "${execPath}",
-      "args": [
-        "--extensionDevelopmentPath=${workspaceFolder}"
-      ]
-    },
-    {
-      "name": "Build",
-      "type": "node",
-      "request": "launch",
-      "runtimeExecutable": "npm",
-      "runtimeArgs": [
-        "run-script",
-        "build"
-      ],
-      "cwd": "${workspaceFolder}",
-      "console": "integratedTerminal"
-    },
-    {
       "name": "Simple (JSON5)",
       "type": "node",
       "request": "launch",
@@ -88,6 +67,26 @@
         "--output-dir",
         "./examples/output",
         "./examples/advanced/src/blackboard.yaml"
+      ],
+      "cwd": "${workspaceFolder}",
+      "console": "integratedTerminal"
+    },
+    {
+      "name": "Advanced (all YAML) (watch)",
+      "type": "node",
+      "request": "launch",
+      "runtimeExecutable": "npm",
+      "runtimeArgs": [
+        "run-script",
+        "exec",
+        "--",
+        "--nerd",
+        "--watch",
+        "--output-dir",
+        "./examples/output",
+        "./examples/advanced/src/blackboard.yaml",
+        "./examples/advanced/src/bubblegum-goth.yaml",
+        "./examples/advanced/src/corporate.yaml",
       ],
       "cwd": "${workspaceFolder}",
       "console": "integratedTerminal"

--- a/examples/advanced/src/blackboard.yaml
+++ b/examples/advanced/src/blackboard.yaml
@@ -18,7 +18,7 @@ config:
 
 vars:
   main: $(colors.white)
-  inverse: invert($(main))
+  inverse: invert($main)
 
   std:
     # The following define primary basics that can be relied upon by the

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gesslar/aunty",
-  "version": "0.0.16",
+  "version": "0.0.17",
   "displayName": "Aunty Rose",
   "description": "Make gorgeous themes that speak as boldly as you do.",
   "publisher": "gesslar",

--- a/src/build.js
+++ b/src/build.js
@@ -40,6 +40,7 @@ import {fileURLToPath,URL} from "node:url"
 import chokidar from "chokidar"
 import {createHash} from "node:crypto"
 import {performance} from "node:perf_hooks"
+import path from "node:path"
 
 import * as File from "./components/File.js"
 import Compiler from "./components/Compiler.js"
@@ -264,9 +265,14 @@ async function processTheme({input, cwd, options}) {
           })
 
           bundle.watcher.on("change", async changed => {
+            const relative = path.relative(process.cwd(), bundle.file.path)
+            const changedPath = relative.startsWith("..")
+              ? bundle.file.path
+              : relative
+
             Term.status([
               ["modified", rightAlignText("CHANGED", 10)],
-              changed,
+              changedPath,
               ["modified", bundle.file.module]
             ], options)
 


### PR DESCRIPTION
# Update VSCode launch configurations and fix variable reference in YAML

This PR updates the VSCode launch configurations to better support development workflows:
- Removed the "Extension" and "Build" configurations
- Added a new "Advanced (all YAML) (watch)" configuration that processes multiple YAML files
- Updated the "Advanced (YAML) (watch)" configuration to include the "--nerd" flag

Additionally:
- Fixed a variable reference in blackboard.yaml (changed `invert($(main))` to `invert($main)`)
- Improved file path display in watch mode by showing relative paths when possible
- Bumped package version from 0.0.16 to 0.0.17