### PR TITLE
Fix file path handling in watch mode and bump version to 0.0.18

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gesslar/aunty",
-  "version": "0.0.17",
+  "version": "0.0.18",
   "displayName": "Aunty Rose",
   "description": "Make gorgeous themes that speak as boldly as you do.",
   "publisher": "gesslar",

--- a/src/build.js
+++ b/src/build.js
@@ -265,9 +265,9 @@ async function processTheme({input, cwd, options}) {
           })
 
           bundle.watcher.on("change", async changed => {
-            const relative = path.relative(process.cwd(), bundle.file.path)
+            const relative = path.relative(process.cwd(), changed)
             const changedPath = relative.startsWith("..")
-              ? bundle.file.path
+              ? changed
               : relative
 
             Term.status([


### PR DESCRIPTION
Fix bug in file change detection during theme processing

This PR fixes a bug in the `processTheme` function where the wrong file path was being used when detecting changes. The code now correctly uses the `changed` parameter passed to the watcher's "change" event instead of `bundle.file.path`, ensuring that the proper file path is displayed when changes are detected.

Version bumped from 0.0.17 to 0.0.18.