### PR TITLE
Add watch mode functionality and bump version to 0.2.0

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -18,7 +18,7 @@
       "console": "integratedTerminal"
     },
     {
-      "name": "Simple (JSON5)",
+      "name": "Simple (JSON5) (watch)",
       "type": "node",
       "request": "launch",
       "runtimeExecutable": "npm",
@@ -27,6 +27,7 @@
         "exec",
         "--",
         "build",
+        "--watch",
         "--output-dir",
         "./examples/output",
         "./examples/simple/midnight-ocean.json5"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gesslar/aunty",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "displayName": "Aunty Rose",
   "description": "Make gorgeous themes that speak as boldly as you do.",
   "publisher": "gesslar",

--- a/src/components/Compiler.js
+++ b/src/components/Compiler.js
@@ -10,6 +10,7 @@ import * as File from "./File.js"
 import FileObject from "./FileObject.js"
 import AuntyError from "./AuntyError.js"
 import _Term from "./Term.js"
+import Term from "./Term.js"
 
 /**
  * Main compiler class for processing theme source files.
@@ -120,7 +121,6 @@ export default class Compiler {
         throw new AuntyError(
           `Import '${sectionName}' must be a string or an array of strings.`
         )
-
 
       // things should already be resolved at this point as far as
       // the header is concerned

--- a/src/components/DirectoryObject.js
+++ b/src/components/DirectoryObject.js
@@ -54,7 +54,7 @@ export default class DirectoryObject {
    * @param {string} directory - The directory path
    */
   constructor(directory) {
-    const fixedDir = File.fixSlashes(directory)
+    const fixedDir = File.fixSlashes(directory ?? ".")
     const {base,ext} = File.deconstructFilenameToParts(fixedDir)
     const fileUri = File.pathToUri(fixedDir)
     const filePath = File.uriToPath(fileUri)

--- a/src/components/File.js
+++ b/src/components/File.js
@@ -297,6 +297,24 @@ async function assureDirectory(dirObject, options = {}) {
   return dirObject.exists
 }
 
+/**
+ * Computes the relative path from one file or directory to another.
+ *
+ * If the target is outside the source (i.e., the relative path starts with ".."),
+ * returns the absolute path to the target instead.
+ *
+ * @param {FileObject|DirectoryObject} from - The source file or directory object
+ * @param {FileObject|DirectoryObject} to - The target file or directory object
+ * @returns {string} The relative path from `from` to `to`, or the absolute path if not reachable
+ */
+function relativeOrAbsolutePath(from, to) {
+  const relative = path.relative(from.path, to.path)
+
+  return relative.startsWith("..")
+    ? to.path
+    : relative
+}
+
 export {
   // Functions
   assureDirectory,
@@ -312,6 +330,7 @@ export {
   ls,
   pathToUri,
   readFile,
+  relativeOrAbsolutePath,
   uriToPath,
   writeFile,
 }

--- a/src/components/Term.js
+++ b/src/components/Term.js
@@ -63,16 +63,16 @@ export default class Term {
   }
 
   /**
-   * Emit a status line (optionally suppressed).
+   * Emit a status line to the terminal.
    *
-   * This method no longer performs any formatting or colour segment
-   * construction; it simply logs the provided argument (typically a
-   * pre‑formatted string) unless `silent` is true. The rich bracketed / coloured
-   * message assembly previously handled here has been extracted to
-   * `terminalMessage()`. Call that first if you need structured formatting, then
-   * pass or let it call back into `status()`.
+   * Accepts either a plain string or an array of message segments (see
+   * `terminalMessage()` for formatting options). If `silent` is true, output
+   * is suppressed.
    *
-   * @param {string} args - Preformatted status message string.
+   * This is a convenient shortcut for logging status updates, with optional
+   * formatting and easy suppression.
+   *
+   * @param {string | Array<string | [string, string]>} args - Message or segments.
    * @param {object} [options] - Behaviour flags.
    * @param {boolean} options.silent - When true, suppress output.
    * @returns {void}


### PR DESCRIPTION
# Add Watch Mode for Theme Development

This PR adds a robust watch mode to the theme builder, allowing for real-time theme development with automatic rebuilding when source files change.

Key improvements:

- Implemented file watching with chokidar to detect changes in theme files and dependencies
- Added keyboard controls in watch mode (F5 to rebuild, q to quit)
- Improved build pipeline with proper event handling for file changes
- Enhanced terminal output with timing information and file sizes
- Added relative path handling for cleaner output messages
- Fixed dependency tracking to ensure all required files are watched
- Updated VS Code launch configuration to include a watch mode option

The implementation uses an event-driven architecture with proper cleanup of watchers when exiting. Performance metrics are now displayed for each step of the build process (load, compile, write).

Version bumped to 0.2.0 to reflect this significant feature addition.