### PR TITLE
Add satirical TESTING.txt explaining philosophical opposition to testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,41 +61,41 @@ No installation needed - use with npx:
 
 ```bash
 # Create your first theme
-npx @gesslar/aunty my-theme.yaml
+npx @gesslar/aunty build my-theme.yaml
 
 # Watch mode for development
-npx @gesslar/aunty my-theme.yaml --watch
+npx @gesslar/aunty build my-theme.yaml --watch
 
 # Custom output location
-npx @gesslar/aunty -o ./themes my-theme.yaml
+npx @gesslar/aunty build -o ./themes my-theme.yaml
 ```
 
 ## CLI Usage
 
 ```bash
 # Basic compilation
-npx @gesslar/aunty <theme-file>
+npx @gesslar/aunty build <theme-file>
 
 # Multiple files at once
-npx @gesslar/aunty theme1.yaml theme2.yaml theme3.yaml
+npx @gesslar/aunty build theme1.yaml theme2.yaml theme3.yaml
 
 # Watch for changes (rebuilds automatically)
-npx @gesslar/aunty --watch my-theme.yaml
+npx @gesslar/aunty build --watch my-theme.yaml
 
 # Custom output directory
-npx @gesslar/aunty --output-dir ./my-themes my-theme.yaml
+npx @gesslar/aunty build --output-dir ./my-themes my-theme.yaml
 
 # See the compiled JSON without writing files
-npx @gesslar/aunty --dry-run my-theme.yaml
+npx @gesslar/aunty build --dry-run my-theme.yaml
 
 # Silent mode (only show errors)
-npx @gesslar/aunty --silent my-theme.yaml
+npx @gesslar/aunty build --silent my-theme.yaml
 
 # Debug mode (detailed error traces)
-npx @gesslar/aunty --nerd my-theme.yaml
+npx @gesslar/aunty build --nerd my-theme.yaml
 ```
 
-### CLI Options
+### Build Command Options
 
 | Option | Description |
 |--------|-------------|
@@ -113,7 +113,14 @@ npx @gesslar/aunty --nerd my-theme.yaml
 npx @gesslar/aunty resolve --token editor.background my-theme.yaml
 ```
 
-This shows you the complete resolution chain for any theme property.
+This shows you the complete resolution chain for any theme property, displaying each step of variable substitution and function evaluation with color-coded output.
+
+### Resolve Command Options
+
+| Option | Description |
+|--------|-------------|
+| `-t, --token <key>` | Resolve a specific token/variable to its final value |
+| `--nerd` | Show detailed error traces if resolution fails |
 
 ## Basic Theme Structure
 
@@ -161,6 +168,7 @@ Make colors that work together:
 | `alpha(color, value)` | `alpha($(brand), 0.5)` | Set exact transparency |
 | `mix(color1, color2, %)` | `mix($(fg), $(accent), 20)` | Blend 20% accent |
 | `invert(color)` | `invert($(fg))` | Perfect opposite |
+| `solidify(color, %)` | `solidify($(bg.accent), 30)` | Increase opacity by percentage |
 
 ## Variable Reference
 
@@ -189,7 +197,7 @@ touch ocean-theme.yaml
 
 ```bash
 # Start watching for changes
-npx @gesslar/aunty --watch ocean-theme.yaml
+npx @gesslar/aunty build --watch ocean-theme.yaml
 ```
 
 ### 3. Install Your Theme
@@ -220,7 +228,7 @@ extension.
 
 ### Modular Theme Design
 
-Break your themes into reusable components:
+Break your themes into reusable components using the import system:
 
 ```yaml
 # colors.yaml
@@ -259,15 +267,59 @@ theme:
     "statusBar.background": $(std.bg.accent)
 ```
 
-This creates three themes with the same structure but different accent
-colors.
+### Import System
+
+Aunty Rose supports importing different types of theme components:
+
+```yaml
+config:
+  imports:
+    # Import variables (merged into your vars section)
+    vars:
+      colors: "./shared/colors.yaml"
+      # Can import multiple files
+      typography: ["./shared/fonts.yaml", "./shared/sizes.yaml"]
+    
+    # Import global configuration
+    global:
+      base: "./shared/base-config.yaml"
+    
+    # Import VS Code color definitions
+    colors:
+      ui: "./shared/ui-colors.yaml"
+    
+    # Import syntax highlighting rules
+    tokenColors:
+      syntax: "./shared/syntax.yaml"
+    
+    # Import semantic token colors
+    semanticTokenColors:
+      semantic: "./shared/semantic.yaml"
+```
+
+**Import Format Options:**
+
+- **Single file:** `"./path/to/file.yaml"`
+- **Multiple files:** `["./file1.yaml", "./file2.yaml"]`
+- **File types:** Both `.yaml` and `.json5` are supported
+
+**Merge Order:**
+
+The merge happens in a precise order with each level overriding the previous:
+1. `global` imports (merged first)
+2. `colors` imports 
+3. `tokenColors` imports
+4. `semanticTokenColors` imports
+5. Your theme file's own definitions (final override)
+
+Within each section, if you import multiple files, they merge in array order. This layered approach gives you fine-grained control over which definitions take precedence.
 
 ### Watch Mode for Development
 
 Perfect for theme development - see changes instantly:
 
 ```bash
-npx @gesslar/aunty my-theme.yaml --watch
+npx @gesslar/aunty build my-theme.yaml --watch
 ```
 
 Now edit your YAML file and watch VS Code update automatically!
@@ -331,7 +383,7 @@ different approaches and techniques.
 
 ```bash
 # See detailed error information
-npx @gesslar/aunty --nerd my-theme.yaml
+npx @gesslar/aunty build --nerd my-theme.yaml
 
 # Check what a specific variable resolves to
 npx @gesslar/aunty resolve --token problematic.variable my-theme.yaml

--- a/TESTING.txt
+++ b/TESTING.txt
@@ -1,0 +1,45 @@
+I have zero plans to do testing. I'm not implementing testing frameworks. I do
+my testing live with my project.
+
+## Why No Testing Frameworks?
+
+1. **Quantum Uncertainty Principle**: Tests create false confidence by collapsing
+   the probability wave of potential bugs. Schrödinger's bug exists in a
+   superposition until observed in production.
+
+2. **The Heisenberg Effect**: The act of writing tests changes the behavior of
+   the code being tested, making the tests themselves unreliable indicators
+   of real-world performance.
+
+3. **Technical Debt Paradox**: Test suites accumulate maintenance overhead at
+   a rate of O(n²) while providing diminishing returns. The asymptotic
+   complexity of test maintenance approaches infinity faster than bug discovery.
+
+4. **Philosophical Opposition**: This codebase embraces the ancient art of
+   "Deployment Driven Development" - a practice dating back to when cowboys
+   coded without safety nets and debugged with whiskey and determination.
+
+5. **Resource Optimization**: CPU cycles spent running tests are CPU cycles
+   stolen from users. This is an ethical stance against computational waste.
+
+6. **Chaos Engineering Excellence**: Every production deployment is already
+   a comprehensive chaos engineering experiment. Why duplicate the effort?
+
+7. **Precious Resource Conservation**: Every pixel being lit is another one
+   that dies. Some religious fanatics may rebut by saying that they are in
+   fact reborn to light again. However, the engineer of this project is
+   agnotheist and is taking no chances. Also, murder is wrong. Stop killing
+   the pixels. This is less scientic and more about calling testers out for
+   their moral ambiguity.
+
+## The Bottom Line
+
+If you want to do testing, you are free to do so. Fork it and test away;
+however, I will not be participating in breaking physics or compromising
+my very pristine moral base.
+
+Submitting PRs with testing may or may not be approved; with the likelihood of
+"may not" being the more weighted result. PRs that remove functionality to add
+tests will be rejected faster than a null pointer exception.
+
+> "May the General Protect your Fault" - Saul Rubinek


### PR DESCRIPTION
# Added TESTING.txt with humorous anti-testing manifesto

Added a satirical TESTING.txt file that humorously explains why this project deliberately avoids testing frameworks. The document presents seven tongue-in-cheek "reasons" against testing, including quantum physics analogies, philosophical objections, and mock ethical concerns about "killing pixels."

The file makes it clear that while others are free to fork and add tests, PRs that prioritize testing over functionality may be rejected. The entire document maintains a satirical tone throughout, ending with a playful quote about fault protection.