### PR TITLE
Await building event emission in Session run method

### DIFF
--- a/src/components/Session.js
+++ b/src/components/Session.js
@@ -40,7 +40,7 @@ export default class AuntySession {
 
   async run() {
     this.#building = true
-    this.#command.asyncEmit("building")
+    await this.#command.asyncEmit("building")
 
     await this.#buildPipeline()
 


### PR DESCRIPTION
Fixed asynchronous event emission in `AuntySession.run()` by adding the `await` keyword to ensure proper handling of the "building" event.