### PR TITLE
Rename example files and refactor variable references to use $ syntax

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -18,7 +18,7 @@
         "--watch",
         "--output-dir",
         "./examples/output",
-        "./examples/simple/midnight-ocean.json5"
+        "./examples/simple/midnight-ocean-json5.json5"
       ],
       "cwd": "${workspaceFolder}",
       "console": "integratedTerminal"
@@ -35,7 +35,7 @@
         "build",
         "--output-dir",
         "./examples/output",
-        "./examples/simple/midnight-ocean.yaml"
+        "./examples/simple/midnight-ocean-yaml.yaml"
       ],
       "cwd": "${workspaceFolder}",
       "console": "integratedTerminal"
@@ -52,7 +52,7 @@
         "build",
         "--output-dir",
         "./examples/output",
-        "./examples/simple/midnight-ocean-mixed.yaml"
+        "./examples/simple/midnight-ocean-mixed-colour-spaces.yaml"
       ],
       "cwd": "${workspaceFolder}",
       "console": "integratedTerminal"

--- a/examples/advanced/import/colors.yaml
+++ b/examples/advanced/import/colors.yaml
@@ -1,747 +1,734 @@
-vars:
-  opacity:
-    faint: 0.05
-    mild: 0.25
-    mid: 0.5
-    strong: 0.8
-    strongest: 0.95
-
 theme:
   colors:
-    contrastActiveBorder: $(transparent)
-    contrastBorder: $(transparent)
+    contrastActiveBorder: $transparent
+    contrastBorder: $transparent
     # Let's get some of the singletons out of the way first
-    focusBorder: $(control.outline.focus)
-    foreground: $(std.fg)
+    focusBorder: $control.outline.focus
+    foreground: $std.fg
     selection:
-      background: $(std.bg.accent.faint)
-    descriptionForeground: $(std.fg.inactive)
-    errorForeground: $(std.fg.error)
+      background: $std.bg.accent.faint
+    descriptionForeground: $std.fg.inactive
+    errorForeground: $std.fg.error
 
     icon:
-      foreground: $(std.fg)
+      foreground: $std.fg
 
     sash:
-      hoverBorder: $(std.outline.faint)
+      hoverBorder: $std.outline.faint
 
     widget:
-      shadow: $(control.shadow)
-      border: $(control.outline)
+      shadow: $control.shadow
+      border: $control.outline
 
     # Title Bar colors
     titleBar:
       # Active
-      activeForeground: $(std.fg)
-      activeBackground: $(std.bg.panel.outer)
+      activeForeground: $std.fg
+      activeBackground: $std.bg.panel.outer
       # Inactive
-      inactiveForeground: $(std.fg.inactive)
-      inactiveBackground: $(std.bg.panel.outer.inactive)
+      inactiveForeground: $std.fg.inactive
+      inactiveBackground: $std.bg.panel.outer.inactive
       # Title Bar Border
-      border: $(std.outline.faint)
+      border: $std.outline.faint
     # Menu and Menu Bar
     # Menu bar is the top that houses menu; file, edit, etc
     menubar:
       # These are actually hovers, idk why they don't call them that
-      selectionForeground: $(std.fg.hover)
-      selectionBackground: $(std.bg.hover)
-      # selectionBorder: $(std.outline) # Enabling this will draw a dashed border
+      selectionForeground: $std.fg.hover
+      selectionBackground: $std.bg.hover
+      # selectionBorder: $std.outline # Enabling this will draw a dashed border
     # Menu (Dropdowns themselves)
     menu:
       # Normal
-      foreground: $(titleBar.activeForeground)
-      background: $(titleBar.activeBackground)
+      foreground: $titleBar.activeForeground
+      background: $titleBar.activeBackground
       # Menu hover
-      selectionForeground: $(menubar.selectionForeground)
-      selectionBackground: $(menubar.selectionBackground)
-      selectionBorder: $(std.outline)
+      selectionForeground: $menubar.selectionForeground
+      selectionBackground: $menubar.selectionBackground
+      selectionBorder: $std.outline
       # Menu Separator & Border
-      separatorBackground: $(std.line.whisper)
-      border: $(std.outline.whisper)
+      separatorBackground: $std.line.whisper
+      border: $std.outline.whisper
 
     # Badge
     badge:
-      foreground: $(std.fg.badge)
-      background: $(std.bg.badge)
+      foreground: $std.fg.badge
+      background: $std.bg.badge
 
     # Side bar
     sideBar:
-      foreground: $(std.fg)
-      background: $(std.bg.panel.inner)
-      border: $(std.outline.whisper)
-      dropBackground: $(std.bg.accent.whisper)
+      foreground: $std.fg
+      background: $std.bg.panel.inner
+      border: $std.outline.whisper
+      dropBackground: $std.bg.accent.whisper
     sideBarTitle:
-      foreground: $(std.fg.accent.secondary)
+      foreground: $std.fg.accent.secondary
     sideBarSectionHeader:
-      foreground: $(std.fg.secondary)
-      background: darken($(std.bg.panel.inner), 15)
-      border: $(std.outline.whisper)
+      foreground: $std.fg.secondary
+      background: darken($std.bg.panel.inner, 15)
+      border: $std.outline.whisper
 
     # Git colors
     # I can't get these to work. Maybe you can? nfi
     gitDecoration:
-      addedResourceForeground: $(status.added)
-      modifiedResourceForeground: $(status.modified)
-      deletedResourceForeground: $(status.deleted)
-      renamedResourceForeground: mix($(gitDecoration.addedResourceForeground), $(gitDecoration.deletedResourceForeground), 50)
-      stageModifiedResourceForeground: $(gitDecoration.modifiedResourceForeground)
-      stageDeletedResourceForeground: $(gitDecoration.deletedResourceForeground)
-      untrackedResourceForeground: lighten($(gitDecoration.addedResourceForeground), 25)
-      ignoredResourceForeground: $(status.ignored)
-      conflictingResourceForeground: $(status.error)
-      submoduleResourceForeground: $(status.info)
+      addedResourceForeground: $status.added
+      modifiedResourceForeground: $status.modified
+      deletedResourceForeground: $status.deleted
+      renamedResourceForeground: mix($gitDecoration.addedResourceForeground, $gitDecoration.deletedResourceForeground, 50)
+      stageModifiedResourceForeground: $gitDecoration.modifiedResourceForeground
+      stageDeletedResourceForeground: $gitDecoration.deletedResourceForeground
+      untrackedResourceForeground: lighten($gitDecoration.addedResourceForeground, 25)
+      ignoredResourceForeground: $status.ignored
+      conflictingResourceForeground: $status.error
+      submoduleResourceForeground: $status.info
     git:
       blame:
-        editorDecorationForeground: fade($(gitDecoration.addedResourceForeground), $opacity.mid)
+        editorDecorationForeground: fade($gitDecoration.addedResourceForeground, 0.5)
     # Source Control Graph colors
     scmGraph:
-      historyItemHoverLabelForeground: $(std.fg.hover)
-      historyItemHoverAdditionsForeground: $(std.fg.success)
-      historyItemHoverDeletionsForeground: $(std.fg.error)
+      historyItemHoverLabelForeground: $std.fg.hover
+      historyItemHoverAdditionsForeground: $std.fg.success
+      historyItemHoverDeletionsForeground: $std.fg.error
       # Default label colors (hover background box)
-      historyItemHoverDefaultLabelForeground: $(std.fg.hover)
-      historyItemHoverDefaultLabelBackground: $(std.bg.hover)
+      historyItemHoverDefaultLabelForeground: $std.fg.hover
+      historyItemHoverDefaultLabelBackground: $std.bg.hover
       # Graph lines: 5 alternating colors
-      foreground1: $(level.1)
-      foreground2: $(level.2)
-      foreground3: $(level.3)
-      foreground4: $(level.4)
-      foreground5: $(level.5)
+      foreground1: $level.1
+      foreground2: $level.2
+      foreground3: $level.3
+      foreground4: $level.4
+      foreground5: $level.5
       # Branch / tag references
-      historyItemRefColor: $(std.bg.accent)
-      historyItemRemoteRefColor: $(std.bg.accent.secondary)
-      historyItemBaseRefColor: lighten($(scmGraph.historyItemRefColor), 25)
+      historyItemRefColor: $std.bg.accent
+      historyItemRemoteRefColor: $std.bg.accent.secondary
+      historyItemBaseRefColor: lighten($scmGraph.historyItemRefColor, 25)
 
     statusBar:
-      foreground: $(control.fg)
-      background: $(control.bg)
-      border: $(control.outline)
-      # No Folder Open - no reason to differentiate
-      noFolderForeground: darken($(statusBar.foreground), 10)
-      noFolderBackground: darken($(statusBar.background), 10)
-      noFolderBorder: darken($(statusBar.border), 10)
-      # Debugging (stronger presence, but still on-brand)
-      debuggingBackground: $(std.bg.accent.secondary)
-      debuggingForeground: $(std.fg.accent.secondary)
-      debuggingBorder: $(std.outline.secondary)
-      focusBorder: $(std.outline)
+      foreground: $std.fg
+      background: $std.bg.panel.outer
+      border: $control.outline
+      # No Folder Open
+      noFolderForeground: darken($statusBar.foreground, 10)
+      noFolderBackground: darken($statusBar.background, 10)
+      noFolderBorder: darken($statusBar.border, 10)
+      # Debugging
+      debuggingBackground: $control.bg
+      debuggingForeground: lighten($std.fg.accent, 25)
+      debuggingBorder: $std.outline.secondary
+      focusBorder: $std.outline
     statusBarItem:
       # Status Bar Item Interaction
-      hoverForeground: $(std.fg.hover)
-      hoverBackground: $(std.bg.hover)
-      activeBackground: lighten($(statusBarItem.hoverBackground), 25)
+      hoverForeground: $std.fg.hover
+      hoverBackground: $std.bg.hover
+      activeBackground: lighten($statusBarItem.hoverBackground, 25)
       # Compact hover (for overflow/duals)
-      compactHoverBackground: lighten($(statusBarItem.hoverBackground), 25)
+      compactHoverBackground: lighten($statusBarItem.hoverBackground, 25)
       # Focus Styles
-      focusBorder: $(std.outline.faint.strong)
+      focusBorder: $std.outline.faint.strong
       # Prominent Items
-      prominentForeground: lighten($(std.bg.accent), 100)
-      prominentBackground: darken($(std.bg.accent), 35)
-      prominentHoverForeground: $(statusBarItem.prominentForeground)
-      prominentHoverBackground: lighten($(statusBarItem.prominentBackground), 25)
+      prominentForeground: lighten($std.bg.accent, 100)
+      prominentBackground: darken($std.bg.accent, 35)
+      prominentHoverForeground: $statusBarItem.prominentForeground
+      prominentHoverBackground: lighten($statusBarItem.prominentBackground, 25)
       # Remote Indicator
-      remoteForeground: $(statusBar.foreground)
-      remoteBackground: $(transparent)
-      remoteHoverForeground: $(statusBarItem.hoverForeground)
-      remoteHoverBackground: $(statusBarItem.hoverBackground)
+      remoteForeground: $statusBar.foreground
+      remoteBackground: $transparent
+      remoteHoverForeground: $statusBarItem.hoverForeground
+      remoteHoverBackground: $statusBarItem.hoverBackground
       # Offline Indicator
-      offlineForeground: invert($(statusBarItem.prominentForeground))
-      offlineBackground: invert($(statusBarItem.prominentBackground))
-      offlineHoverForeground: invert($(statusBarItem.prominentHoverForeground))
-      offlineHoverBackground: invert($(statusBarItem.prominentHoverBackground))
+      offlineForeground: invert($statusBarItem.prominentForeground)
+      offlineBackground: invert($statusBarItem.prominentBackground)
+      offlineHoverForeground: invert($statusBarItem.prominentHoverForeground)
+      offlineHoverBackground: invert($statusBarItem.prominentHoverBackground)
       # Error State Items
-      errorForeground: $(std.fg)
-      errorBackground: $(std.bg.error)
-      errorHoverForeground: $(statusBarItem.errorForeground)
-      errorHoverBackground: solidify($(statusBarItem.errorBackground), 30)
+      errorForeground: $std.fg
+      errorBackground: $std.bg.error
+      errorHoverForeground: $statusBarItem.errorForeground
+      errorHoverBackground: solidify($statusBarItem.errorBackground, 30)
       # Warning State Items
-      warningForeground: $(std.fg)
-      warningBackground: $(std.bg.warning)
-      warningHoverForeground: $(statusBarItem.warningForeground)
-      warningHoverBackground: solidify($(statusBarItem.warningBackground), 30)
+      warningForeground: $std.fg
+      warningBackground: $std.bg.warning
+      warningHoverForeground: $statusBarItem.warningForeground
+      warningHoverBackground: solidify($statusBarItem.warningBackground, 30)
 
     # Activity Bar
     activityBar:
       # Base
-      foreground: $(std.fg)
-      background: $(std.bg.panel.inner)
-      inactiveForeground: $(std.fg.inactive)
-      border: $(std.outline.whisper)
+      foreground: $std.fg
+      background: $std.bg.panel.inner
+      inactiveForeground: $std.fg.inactive
+      border: $std.outline.whisper
       # Active State
-      activeBackground: $(std.bg.accent.faint)
-      activeBorder: $(std.line.faint)
-      activeFocusBorder: $(std.line.faint.strong)
+      activeBackground: $std.bg.accent.faint
+      activeBorder: $std.line.faint
+      activeFocusBorder: $std.line.faint.strong
       # Dragging
-      dropBorder: $(activityBar.activeBorder)
+      dropBorder: $activityBar.activeBorder
     # Badge (normal)
     activityBarBadge:
-      foreground: $(std.fg.badge)
-      background: $(std.bg.badge)
+      foreground: $std.fg.badge
+      background: $std.bg.badge
     # Badge (warning)
     activityWarningBadge:
-      foreground: $(std.fg.badge)
-      background: $(status.warning)
+      foreground: $std.fg.badge
+      background: $status.warning
     # Badge (error)
     activityErrorBadge:
-      foreground: $(std.fg.badge)
-      background: $(status.error)
+      foreground: $std.fg.badge
+      background: $status.error
     # Activity Bar Top
     activityBarTop:
-      foreground: $(activityBar.foreground)
-      background: $(activityBar.background)
-      inactiveForeground: $(activityBar.inactiveForeground)
-      activeBackground: $(activityBar.activeBackground)
-      activeBorder: $(activityBar.activeBorder)
-      dropBorder: $(activityBar.dropBorder)
+      foreground: $activityBar.foreground
+      background: $activityBar.background
+      inactiveForeground: $activityBar.inactiveForeground
+      activeBackground: $activityBar.activeBackground
+      activeBorder: $activityBar.activeBorder
+      dropBorder: $activityBar.dropBorder
     # Profiles
     profiles:
-      sashBorder: $(std.outline.whisper)
+      sashBorder: $std.outline.whisper
     profileBadge:
-      foreground: $(std.fg.badge)
-      background: $(std.bg.badge)
+      foreground: $std.fg.badge
+      background: $std.bg.badge
 
     # Controls and inputs and things of that nature
     # Toolbars
     toolbar:
-      hoverBackground: $(std.bg.hover)
-      # hoverOutline: $(std.outline.hover)
-      activeBackground: lighten($(toolbar.hoverBackground), 25)
+      hoverBackground: $std.bg.hover
+      # hoverOutline: $std.outline.hover # enable this if you really want dotted underlines
+      activeBackground: lighten($toolbar.hoverBackground, 25)
     # Editor Actions - no idea what this is. i mean, i know what the
     # editorAction toolbar is, but these settings don't seem to apply
     editorActionList:
-      foreground: $(std.fg)
-      background: $(std.bg.panel.inner)
-      focusForeground: $(std.fg)
-      focusBackground: $(std.bg.panel.inner.inactive)
+      foreground: $std.fg
+      background: $std.bg.panel.inner
+      focusForeground: $std.fg
+      focusBackground: $std.bg.panel.inner.inactive
     # Button control
     button:
-      foreground: $(control.fg)
-      background: $(control.bg)
-      border: $(control.outline)
-      hoverBackground: $(control.bg.hover)
-      secondaryForeground: $(control.fg.secondary)
-      secondaryBackground: $(control.bg.secondary)
-      secondaryHoverBackground: $(control.bg.secondary.hover)
-      separator: $(std.line.faint)
+      foreground: $control.fg
+      background: $control.bg
+      border: $control.outline
+      hoverBackground: $control.bg.hover
+      secondaryForeground: $control.fg.secondary
+      secondaryBackground: $control.bg.secondary
+      secondaryHoverBackground: $control.bg.secondary.hover
+      separator: $std.line.faint
     # Checkbox
     checkbox:
-      foreground: $(control.fg)
-      background: $(control.bg)
-      border: $(control.outline)
-      selectBackground: $(control.bg.active)
-      selectBorder: $(control.outline.focus)
+      foreground: $control.fg
+      background: $control.bg
+      border: $control.outline
+      selectBackground: $control.bg.active
+      selectBorder: $control.outline.focus
     # Radio buttons
     radio:
-      activeForeground: $(control.fg.active)
-      activeBackground: $(control.bg.active)
-      activeBorder: $(control.outline.focus)
-      inactiveForeground: $(control.fg)
-      inactiveBackground: $(control.bg)
-      inactiveBorder: $(control.outline)
-      inactiveHoverBackground: $(control.bg.hover)
+      activeForeground: $control.fg.active
+      activeBackground: $control.bg.active
+      activeBorder: $control.outline.focus
+      inactiveForeground: $control.fg
+      inactiveBackground: $control.bg
+      inactiveBorder: $control.outline
+      inactiveHoverBackground: $control.bg.hover
     # Dropdown control
     dropdown:
-      foreground: $(control.fg)
-      background: $(menu.background)
-      listBackground: $(menu.background)
-      border: $(control.outline)
+      foreground: $control.fg
+      background: $menu.background
+      listBackground: $menu.background
+      border: $control.outline
     # Input control
     input:
-      foreground: $(control.fg)
-      placeholderForeground: $(std.fg.accent.secondary)
-      background: $(control.bg)
-      border: $(control.outline)
+      foreground: $control.fg
+      placeholderForeground: $std.fg.accent.secondary
+      background: $control.bg
+      border: $control.outline
     inputOption: # These are buttons!
-      activeForeground: $(button.foreground)
-      activeBackground: $(button.background)
-      activeBorder: $(control.outline.active)
-      hoverBackground: $(button.hoverBackground)
+      activeForeground: $button.foreground
+      activeBackground: $button.background
+      activeBorder: $control.outline.active
+      hoverBackground: $button.hoverBackground
     inputValidation:
-      errorForeground: $(std.fg.error)
-      errorBackground: $(std.bg.error)
-      errorBorder: $(std.outline.error)
-      warningForeground: $(std.fg.warning)
-      warningBackground: $(std.bg.warning)
-      warningBorder: $(std.outline.warning)
-      infoForeground: $(std.fg.info)
-      infoBackground: $(std.bg.info)
-      infoBorder: $(std.outline.info)
+      errorForeground: $std.fg.error
+      errorBackground: $std.bg.error
+      errorBorder: $std.outline.error
+      warningForeground: $std.fg.warning
+      warningBackground: $std.bg.warning
+      warningBorder: $std.outline.warning
+      infoForeground: $std.fg.info
+      infoBackground: $std.bg.info
+      infoBorder: $std.outline.info
     # Scrollbar control
     scrollbar:
-      shadow: $(std.shadow)
+      shadow: $shadow
     scrollbarSlider:
-      background: fade($(std.bg.accent.faint), $opacity.strong)
-      hoverBackground: solidify(lighten($(scrollbarSlider.background), 10), 0.50)
-      activeBackground: solidify(lighten($(scrollbarSlider.hoverBackground), 10), 0.25)
+      background: fade($std.bg.accent.faint, 0.80)
+      hoverBackground: solidify(lighten($scrollbarSlider.background, 10), 0.50)
+      activeBackground: solidify(lighten($scrollbarSlider.hoverBackground, 10), 0.25)
     # Progress bar
     progressBar:
-      background: $(std.bg.success)
+      background: $std.bg.success
     # Breadcrumbs colors
     breadcrumb:
-      foreground: $(std.fg.accent)
-      background: $(std.bg.panel.inner)
-      focusForeground: $(std.fg)
-      activeSelectionForeground: mix($(std.fg.accent.secondary), $(std.fg), 50)
+      foreground: $std.fg.accent
+      background: $std.bg.panel.inner
+      focusForeground: $std.fg
+      activeSelectionForeground: mix($std.fg.accent.secondary, $std.fg, 50)
     breadcrumbPicker:
-      background: $(menu.background)
+      background: $menu.background
     # Lists and trees
     list:
-      activeSelectionForeground: $(std.fg)
-      activeSelectionBackground: $(std.bg.accent.whisper)
-      activeSelectionIconForeground: $(std.fg.accent.secondary)
-      inactiveSelectionForeground: $(list.activeSelectionForeground)
-      inactiveSelectionBackground: $(list.activeSelectionBackground)
-      inactiveSelectionIconForeground: $(list.activeSelectionIconForeground)
-      focusForeground: $(list.activeSelectionForeground)
-      focusBackground: lighten($(list.activeSelectionBackground), 25)
-      focusHighlightForeground: $(list.activeSelectionForeground)
-      focusOutline: $(std.outline.strong)
-      focusAndSelectionOutline: $(std.outline.faint.strong)
-      hoverForeground: $(control.fg.hover)
-      hoverBackground: $(control.bg.hover)
-      dropBackground: $(std.bg.drop)
-      dropBetweenBackground: solidify($(std.bg.accent), .25)
-      highlightForeground: $(std.fg.accent.secondary)
-      filterMatchBackground: $(std.bg.accent.faint)
-      filterMatchBorder: $(std.outline.faint.strong)
-      errorForeground: $(std.fg.error)
-      warningForeground: $(std.fg.warning)
-      invalidItemForeground: $(std.fg.error)
-      deemphasizedForeground: $(std.fg.inactive)
+      activeSelectionForeground: $std.fg
+      activeSelectionBackground: $std.bg.accent.whisper
+      activeSelectionIconForeground: $std.fg.accent.secondary
+      inactiveSelectionForeground: $list.activeSelectionForeground
+      inactiveSelectionBackground: $list.activeSelectionBackground
+      inactiveSelectionIconForeground: $list.activeSelectionIconForeground
+      focusForeground: $list.activeSelectionForeground
+      focusBackground: lighten($list.activeSelectionBackground, 25)
+      focusHighlightForeground: $list.activeSelectionForeground
+      focusOutline: $std.outline.strong
+      focusAndSelectionOutline: $std.outline.faint.strong
+      hoverForeground: $control.fg.hover
+      hoverBackground: $control.bg.hover
+      dropBackground: $std.bg.drop
+      dropBetweenBackground: solidify($std.bg.accent, .25)
+      highlightForeground: $std.fg.accent.secondary
+      filterMatchBackground: $std.bg.accent.faint
+      filterMatchBorder: $std.outline.faint.strong
+      errorForeground: $std.fg.error
+      warningForeground: $std.fg.warning
+      invalidItemForeground: $std.fg.error
+      deemphasizedForeground: $std.fg.inactive
     listFilterWidget:
-      background: $(control.bg)
-      outline: $(control.outline)
-      noMatchesOutline: $(std.outline.warning)
-      shadow: $(control.shadow)
+      background: $control.bg
+      outline: $control.outline
+      noMatchesOutline: $std.outline.warning
+      shadow: $control.shadow
     tree:
-      indentGuidesStroke: $(std.line)
-      inactiveIndentGuidesStroke: $(std.line.whisper)
+      indentGuidesStroke: $std.line
+      inactiveIndentGuidesStroke: $std.line.whisper
       # The following two are used in the profiles page.
-      tableColumnsBorder: $(control.outline) # Hover over a table/list, separators
-      tableOddRowsBackground: fade($(control.bg.secondary), $opacity.strongest) # Weirdly used as background for column headers
+      tableColumnsBorder: $control.outline # Hover over a table/list, separators
+      tableOddRowsBackground: fade($control.bg.secondary, 0.95) # Weirdly used as background for column headers
 
     # Editor Groups & Tabs
     # Editor Groups
     editorGroupHeader:
-      noTabsBackground: $(std.bg.panel.inner) # workbench.editor.showTabs = "single"
-      tabsBackground: $(std.bg.panel.inner)
-      tabsBorder: $(std.outline.whisper)
-      border: $(std.outline.whisper)
+      noTabsBackground: $std.bg.panel.inner # workbench.editor.showTabs = "single"
+      tabsBackground: $std.bg.panel.inner
+      tabsBorder: $std.outline.whisper
+      border: $std.outline.whisper
     editorGroup:
-      border: $(std.outline.whisper)
-      dropBackground: $(std.bg.drop)
-      emptyBackground: $(std.bg.panel.inner)
-      focusedEmptyBorder: $(std.outline)
-      dropIntoPromptForeground: $(std.fg)
-      dropIntoPromptBackground: $(std.bg.panel.inner)
-      dropIntoPromptBorder: $(std.outline)
+      border: $std.outline.whisper
+      dropBackground: $std.bg.drop
+      emptyBackground: $std.bg.panel.inner
+      focusedEmptyBorder: $std.outline
+      dropIntoPromptForeground: $std.fg
+      dropIntoPromptBackground: $std.bg.panel.inner
+      dropIntoPromptBorder: $std.outline
     # Tabs
     tab:
-      activeForeground: $(std.fg)
-      inactiveForeground: $(std.fg.inactive)
-      unfocusedActiveForeground: $(std.fg.inactive)
-      unfocusedInactiveForeground: $(std.fg.inactive)
-      activeBackground: mix($(std.bg.accent), $(std.bg.panel.inner), 80)
-      inactiveBackground: $(std.bg.panel.inner.inactive)
-      unfocusedActiveBackground: fade($(tab.activeBackground), $opacity.strong)
-      unfocusedInactiveBackground: fade($(std.bg.panel.inner.inactive), $opacity.mid)
-      selectedBackground: lighten($(tab.activeBackground), 100)
-      selectedForeground: $(std.fg)
-      border: $(std.outline.whisper)
-      activeBorder: $(transparent)
-      activeBorderTop: $(std.outline)
-      selectedBorderTop: lighten($(tab.activeBorderTop), 25)
-      unfocusedActiveBorder: $(transparent)
-      unfocusedActiveBorderTop: $(transparent)
-      hoverForeground: $(std.fg.hover)
-      unfocusedHoverForeground: $(std.fg.inactive)
-      hoverBackground: lighten($(tab.activeBackground), 50)
-      unfocusedHoverBackground: darken($(tab.hoverBackground), 20)
-      hoverBorder: $(std.outline)
-      unfocusedHoverBorder: $(std.outline.faint)
-      lastPinnedBorder: $(tab.activeBorderTop)
+      activeForeground: $std.fg
+      inactiveForeground: $std.fg.inactive
+      unfocusedActiveForeground: $std.fg.inactive
+      unfocusedInactiveForeground: $std.fg.inactive
+      activeBackground: mix($std.bg.accent, $std.bg.panel.inner, 80)
+      inactiveBackground: $std.bg.panel.inner.inactive
+      unfocusedActiveBackground: fade($tab.activeBackground, 0.75)
+      unfocusedInactiveBackground: fade($std.bg.panel.inner.inactive, 0.50)
+      selectedBackground: lighten($tab.activeBackground, 100)
+      selectedForeground: $std.fg
+      border: $std.outline.whisper
+      activeBorder: $transparent
+      activeBorderTop: $std.outline
+      selectedBorderTop: lighten($tab.activeBorderTop, 25)
+      unfocusedActiveBorder: $transparent
+      unfocusedActiveBorderTop: $transparent
+      hoverForeground: $std.fg.hover
+      unfocusedHoverForeground: $std.fg.inactive
+      hoverBackground: lighten($tab.activeBackground, 50)
+      unfocusedHoverBackground: darken($tab.hoverBackground, 20)
+      hoverBorder: $std.outline
+      unfocusedHoverBorder: $std.outline.faint
+      lastPinnedBorder: $tab.activeBorderTop
       # Modified Indicator
-      activeModifiedBorder: fade($(status.added), $opacity.mild)
-      inactiveModifiedBorder: fade($(tab.activeModifiedBorder), 0.4)
-      unfocusedActiveModifiedBorder: fade($(tab.activeModifiedBorder), 0.2)
-      unfocusedInactiveModifiedBorder: fade($(tab.inactiveModifiedBorder), 0.2)
+      activeModifiedBorder: fade($status.added, 0.2)
+      inactiveModifiedBorder: fade($tab.activeModifiedBorder, 0.4)
+      unfocusedActiveModifiedBorder: fade($tab.activeModifiedBorder, 0.2)
+      unfocusedInactiveModifiedBorder: fade($tab.inactiveModifiedBorder, 0.2)
 
     # Oof, the editor stuff. SO MUCH EDITOR STUFF!
 
     # Editor pane & splitters
     editor:
-      foreground: $(std.fg)
-      background: $(std.bg.panel.innermost)
+      foreground: $std.fg
+      background: $std.bg.panel.innermost
       # Placeholder Text
       placeholder:
-        foreground: $(std.fg.inactive)
+        foreground: $std.fg.inactive
       # Text selection
-      selectionForeground: $(std.fg)
-      selectionBackground: lighten($(std.highlight.bg.accent), 50)
-      inactiveSelectionBackground: darken($(editor.selectionBackground), 10)
+      selectionForeground: $std.fg
+      selectionBackground: lighten($std.highlight.bg.accent, 50)
+      inactiveSelectionBackground: darken($editor.selectionBackground, 10)
       # Matching content
-      selectionHighlightBackground: mix($(std.bg.accent.faint), $(std.bg.panel.innermost), 90)
-      selectionHighlightBorder: lighten($(editor.selectionHighlightBackground), 25)
+      selectionHighlightBackground: mix($std.bg.accent.faint, $std.bg.panel.innermost, 90)
+      selectionHighlightBorder: lighten($editor.selectionHighlightBackground, 25)
       # Word/Identifier highlights
-      wordHighlightBackground: $(std.highlight.bg.read) # Background color of a symbol during read-access, like reading a variable.
-      wordHighlightBorder: $(std.highlight.fg.read) # Border color of a symbol during read-access.
-      wordHighlightStrongBackground: $(std.highlight.bg.write) # Background color of a symbol during write-access, like writing to a variable.
-      wordHighlightStrongBorder: $(std.highlight.fg.write) # Border color of a symbol during write-access.
-      wordHighlightTextBackground: $(std.highlight.bg.accent) # Color for regions with the same content as the selection.
-      wordHighlightTextBorder: $(std.highlight.fg.accent) # Border color for regions with the same content as the selection.
+      wordHighlightBackground: $std.highlight.bg.read # Background color of a symbol during read-access, like reading a variable.
+      wordHighlightBorder: $std.highlight.fg.read # Border color of a symbol during read-access.
+      wordHighlightStrongBackground: $std.highlight.bg.write # Background color of a symbol during write-access, like writing to a variable.
+      wordHighlightStrongBorder: $std.highlight.fg.write # Border color of a symbol during write-access.
+      wordHighlightTextBackground: $std.highlight.bg.accent # Color for regions with the same content as the selection.
+      wordHighlightTextBorder: $std.highlight.fg.accent # Border color for regions with the same content as the selection.
       # Find matches
       #
       # GDI MS - Why you reverse findMatchHighlightForeground and findMatchForeground
       # I effing see you.
       #
       # CURRENT match (focused one)
-      findMatchHighlightForeground: fade($(std.bg.panel.innermost), 0.10)
-      findMatchBackground: $(std.highlight.bg.match) # Background color of the current find match.
-      findMatchBorder: fade($(editor.findMatchHighlightForeground), 0.5)
+      findMatchHighlightForeground: fade($std.bg.panel.innermost, 0.10)
+      findMatchBackground: $std.highlight.bg.match # Background color of the current find match.
+      findMatchBorder: fade($editor.findMatchHighlightForeground, 0.5)
       # OTHER matches (passive highlights)
-      findMatchForeground: $(std.highlight.bg.match) # Foreground color of the current find match.
-      findMatchHighlightBackground: fade($(editor.findMatchHighlightForeground), 0.25)
-      findMatchHighlightBorder: fade($(editor.findMatchForeground), 0.5)
+      findMatchForeground: $std.highlight.bg.match # Foreground color of the current find match.
+      findMatchHighlightBackground: fade($editor.findMatchHighlightForeground, 0.25)
+      findMatchHighlightBorder: fade($editor.findMatchForeground, 0.5)
       # Range highlights
-      findRangeHighlightBackground: fade($(editor.findMatchHighlightBackground), 0.90) # Background color of the range highlight.
-      findRangeHighlightBorder: $(editor.findMatchHighlightBorder) # Border color of the range highlight.
+      findRangeHighlightBackground: fade($editor.findMatchHighlightBackground, 0.90) # Background color of the range highlight.
+      findRangeHighlightBorder: $editor.findMatchHighlightBorder # Border color of the range highlight.
       # Folding
-      foldBackground: $(std.bg.accent.whisper)
-      foldPlaceholderForeground: lighten($(std.fg.accent), 50)
+      foldBackground: $std.bg.accent.whisper
+      foldPlaceholderForeground: lighten($std.fg.accent, 50)
       # Active line highlight
-      lineHighlightBackground: fade(lighten($(std.bg.panel.innermost), 25), 0.25)
-      lineHighlightBorder: fade($(std.outline.whisper), 0.25) # Border color of the active line highlight.
+      lineHighlightBackground: fade(lighten($std.bg.panel.innermost, 25) , 0.25)
+      lineHighlightBorder: fade($std.outline.whisper, 0.25) # Border color of the active line highlight.
       # Hover highlight
-      hoverHighlightBackground: fade($(std.bg.accent.faint), 0.60) # Background color of the hover highlight.
+      hoverHighlightBackground: fade($std.bg.accent.faint, 0.60) # Background color of the hover highlight.
       # Symbol navigation (e.g., Go to Definition)
-      symbolHighlightBackground: $(editor.findMatchHighlightBackground)
-      symbolHighlightBorder: $(editor.findMatchHighlightBorder) # Border color of the symbol highlight.
+      symbolHighlightBackground: $editor.findMatchHighlightBackground
+      symbolHighlightBorder: $editor.findMatchHighlightBorder # Border color of the symbol highlight.
       # Range highlight (Quick Open, Ctrl+Shift+O, etc.)
-      rangeHighlightBackground: $(editor.findRangeHighlightBackground) # Background color of the range highlight.
-      rangeHighlightBorder: $(editor.findRangeHighlightBorder) # Border color of the range highlight.
+      rangeHighlightBackground: $editor.findRangeHighlightBackground # Background color of the range highlight.
+      rangeHighlightBorder: $editor.findRangeHighlightBorder # Border color of the range highlight.
       # Inline Values (Editor)
-      inlineValuesForeground: fade($(std.fg.info), 0.15) # Subtle, but visible
-      inlineValuesBackground: fade($(std.bg.info), 0.90) # Soft, muted background
+      inlineValuesForeground: fade($std.fg.info, 0.15) # Subtle, but visible
+      inlineValuesBackground: fade($std.bg.info, 0.90) # Soft, muted background
       # Stack Frame Highlights (Editor)
-      stackFrameHighlightBackground: alpha($(editor.findMatchHighlightBackground), 0.10) # Soft, ambient highlight
-      focusedStackFrameHighlightBackground: alpha($(editor.findMatchHighlightBackground), 0.20) # Stronger focus highlight
-      snippetTabstopHighlightBackground: $(std.bg.accent.faint) # soft, ambient glow
-      snippetTabstopHighlightBorder: $(std.outline.faint) # soft, ambient border
-      snippetFinalTabstopHighlightBackground: $(std.bg.accent.faint.strong) # stronger, more pronounced glow
-      snippetFinalTabstopHighlightBorder: $(std.outline.faint.strong) # stronger, more pronounced border
+      stackFrameHighlightBackground: alpha($editor.findMatchHighlightBackground, 0.10) # Soft, ambient highlight
+      focusedStackFrameHighlightBackground: alpha($editor.findMatchHighlightBackground, 0.20) # Stronger focus highlight
+      snippetTabstopHighlightBackground: $std.bg.accent.faint # soft, ambient glow
+      snippetTabstopHighlightBorder: $std.outline.faint # soft, ambient border
+      snippetFinalTabstopHighlightBackground: $std.bg.accent.faint.strong # stronger, more pronounced glow
+      snippetFinalTabstopHighlightBorder: $std.outline.faint.strong # stronger, more pronounced border
 
     # Line Numbers
     editorLineNumber:
-      foreground: $(std.fg.accent.faint)
-      activeForeground: $(std.fg.accent)
-      dimmedForeground: $(std.fg.accent.whisper)
+      foreground: fade($std.fg.accent, .6)
+      activeForeground: fade($std.fg.accent, .1)
+      dimmedForeground: fade($std.fg.accent, .8)
     # Cursor
     editorCursor:
-      foreground: $(std.fg.accent.secondary)
-      background: $(std.bg.panel.outer) # When the cursor is a block, this is the FOREGROUND of the character it's on. Background, my ass.
+      foreground: $std.fg.accent.secondary
+      background: $std.bg.panel.outer # When the cursor is a block, this is the FOREGROUND of the character it's on. Background, my ass.
     # Multi-cursor
     editorMultiCursor:
       primary:
-        foreground: $(editorCursor.foreground)
-        background: $(editorCursor.background)
+        foreground: $editorCursor.foreground
+        background: $editorCursor.background
       secondary:
-        foreground: fade(darken($(editorCursor.foreground), 25), 0.25)
-        background: $(editorCursor.background)
+        foreground: fade(darken($editorCursor.foreground, 25), 0.25)
+        background: $editorCursor.background
     editorPane:
-      background: $(std.bg.panel.inner)
+      background: $std.bg.panel.inner
     sideBySideEditor:
-      horizontalBorder: $(std.outline.faint)
-      verticalBorder: $(std.outline.whisper)
+      horizontalBorder: $std.outline.faint
+      verticalBorder: $std.outline.whisper
 
     # Whitespace
     editorWhitespace:
-      foreground: $(std.fg.accent.whisper) # Whitespace characters (spaces, tabs, etc.) when enabled
+      foreground: $std.fg.accent.whisper # Whitespace characters (spaces, tabs, etc.) when enabled
     # Indent Guides
     editorIndentGuide:
-      background1: alpha($(std.line), .55)
-      background2: darken($(editorIndentGuide.background1), 5)
-      background3: darken($(editorIndentGuide.background2), 5)
-      background4: darken($(editorIndentGuide.background3), 5)
-      background5: darken($(editorIndentGuide.background4), 5)
-      background6: darken($(editorIndentGuide.background5), 5)
-      activeBackground1: lighten($(editorIndentGuide.background1), 25)
-      activeBackground2: lighten($(editorIndentGuide.background1), 25)
-      activeBackground3: lighten($(editorIndentGuide.background1), 25)
-      activeBackground4: lighten($(editorIndentGuide.background1), 25)
-      activeBackground5: lighten($(editorIndentGuide.background1), 25)
-      activeBackground6: lighten($(editorIndentGuide.background1), 25)
+      background1: alpha($std.line, .55)
+      background2: darken($editorIndentGuide.background1, 5)
+      background3: darken($editorIndentGuide.background2, 5)
+      background4: darken($editorIndentGuide.background3, 5)
+      background5: darken($editorIndentGuide.background4, 5)
+      background6: darken($editorIndentGuide.background5, 5)
+      activeBackground1: lighten($editorIndentGuide.background1, 25)
+      activeBackground2: lighten($editorIndentGuide.background1, 25)
+      activeBackground3: lighten($editorIndentGuide.background1, 25)
+      activeBackground4: lighten($editorIndentGuide.background1, 25)
+      activeBackground5: lighten($editorIndentGuide.background1, 25)
+      activeBackground6: lighten($editorIndentGuide.background1, 25)
 
     # Bracket Match
     editorBracketMatch:
-      background: $(std.bg.accent.whisper)
-      border: $(std.outline.faint.strong)
+      background: $std.bg.accent.whisper
+      border: $std.outline.faint.strong
 
     # Bracket Pair Colorization
     editorBracketHighlight:
-      foreground1: $(level.1)
-      foreground2: $(level.2)
-      foreground3: $(level.3)
-      foreground4: $(level.4)
-      foreground5: $(level.5)
-      foreground6: $(level.6)
+      foreground1: $level.1
+      foreground2: $level.2
+      foreground3: $level.3
+      foreground4: $level.4
+      foreground5: $level.5
+      foreground6: $level.6
       unexpectedBracket:
         foreground: "#ff0077"
 
     # Bracket Pair Guides
     editorBracketPairGuide:
       # Backgrounds (inactive scopes)
-      background1: darken($(std.bg.accent.faint), 25)
-      background2: darken($(std.bg.accent.faint), 25)
-      background3: darken($(std.bg.accent.faint), 25)
-      background4: darken($(std.bg.accent.faint), 25)
-      background5: darken($(std.bg.accent.faint), 25)
-      background6: darken($(std.bg.accent.faint), 25)
+      background1: darken($std.bg.accent.faint, 25)
+      background2: darken($std.bg.accent.faint, 25)
+      background3: darken($std.bg.accent.faint, 25)
+      background4: darken($std.bg.accent.faint, 25)
+      background5: darken($std.bg.accent.faint, 25)
+      background6: darken($std.bg.accent.faint, 25)
       # Active scope
-      activeBackground1: $(std.bg.accent.faint)
-      activeBackground2: $(std.bg.accent.faint)
-      activeBackground3: $(std.bg.accent.faint)
-      activeBackground4: $(std.bg.accent.faint)
-      activeBackground5: $(std.bg.accent.faint)
-      activeBackground6: $(std.bg.accent.faint)
+      activeBackground1: $std.bg.accent.faint
+      activeBackground2: $std.bg.accent.faint
+      activeBackground3: $std.bg.accent.faint
+      activeBackground4: $std.bg.accent.faint
+      activeBackground5: $std.bg.accent.faint
+      activeBackground6: $std.bg.accent.faint
 
     # Overview Ruler
     editorOverviewRuler:
-      background: $(std.bg.panel.inner)
-      border: $(std.outline.whisper)
-      findMatchForeground: fade($(editor.findMatchForeground), 0.25)
-      rangeHighlightForeground: $(editor.findMatchHighlightForeground)
-      selectionHighlightForeground: $(editor.findMatchHighlightForeground)
-      wordHighlightForeground: fade($(editor.findMatchForeground), 0.15)
-      wordHighlightStrongForeground: $(editor.wordHighlightStrongBackground)
-      wordHighlightTextForeground: fade($(editor.findMatchForeground), 0.25)
-      modifiedForeground: $(status.modified)
-      addedForeground: $(status.added)
-      deletedForeground: $(status.deleted)
-      errorForeground: $(status.error)
-      warningForeground: $(status.warning)
-      infoForeground: $(status.info)
-      bracketMatchForeground: $(std.fg.accent)
-      inlineChatInserted: darken($(std.bg.success), 50)
-      inlineChatRemoved: darken($(std.bg.error), 50)
-      currentContentForeground: $(std.fg.accent.secondary)
-      incomingContentForeground: $(std.fg.success)
-      commonContentForeground: $(std.fg.info)
+      background: $std.bg.panel.inner
+      border: $std.outline.whisper
+      findMatchForeground: fade($editor.findMatchForeground, 0.25)
+      rangeHighlightForeground: $editor.findMatchHighlightForeground
+      selectionHighlightForeground: $editor.findMatchHighlightForeground
+      wordHighlightForeground: fade($editor.findMatchForeground, 0.15)
+      wordHighlightStrongForeground: $editor.wordHighlightStrongBackground
+      wordHighlightTextForeground: fade($editor.findMatchForeground, 0.25)
+      modifiedForeground: $status.modified
+      addedForeground: $status.added
+      deletedForeground: $status.deleted
+      errorForeground: $status.error
+      warningForeground: $status.warning
+      infoForeground: $status.info
+      bracketMatchForeground: $std.fg.accent
+      inlineChatInserted: darken($std.bg.success, 50)
+      inlineChatRemoved: darken($std.bg.error, 50)
+      currentContentForeground: $std.fg.accent.secondary
+      incomingContentForeground: $std.fg.success
+      commonContentForeground: $std.fg.info
 
     # Editor Diagnostics
     editorError:
-      foreground: $(std.fg.error)
-      border: lighten($(std.outline.error), 100)
-      background: fade($(std.bg.error), 0.60)
+      foreground: $std.fg.error
+      border: lighten($std.outline.error, 100)
+      background: fade($std.bg.error, 0.60)
 
     editorWarning:
-      foreground: $(std.fg.warning)
-      border: lighten($(std.outline.warning), 100)
-      background: fade($(std.bg.warning), 0.60)
+      foreground: $std.fg.warning
+      border: lighten($std.outline.warning, 100)
+      background: fade($std.bg.warning, 0.60)
 
     editorInfo:
-      foreground: $(std.fg.info)
-      border: lighten($(std.outline.info), 100)
-      background: fade($(std.bg.info), 0.60)
+      foreground: $std.fg.info
+      border: lighten($std.outline.info, 100)
+      background: fade($std.bg.info, 0.60)
 
     editorHint:
-      foreground: $(std.fg.success)
-      border: $(std.outline.success)
+      foreground: $std.fg.success
+      border: $std.outline.success
 
     # Problems Icons
     problemsErrorIcon:
-      foreground: $(std.fg.error)
+      foreground: $std.fg.error
     problemsWarningIcon:
-      foreground: $(std.fg.warning)
+      foreground: $std.fg.warning
     problemsInfoIcon:
-      foreground: $(std.fg.info)
+      foreground: $std.fg.info
 
     # Unused Code
-    # editorUnnecessaryCode:
-    #   border: $(std.outline)
-    #   opacity: "#000000c0"
+    editorUnnecessaryCode:
+      border: fade($std.outline.faint, .25)
+      opacity: "#ff0000c0"
 
     # Gutter background
     editorGutter:
-      background: $(std.bg.panel.inner)
+      background: $std.bg.panel.inner
       # Git-style modifications
-      modifiedBackground: $(status.modified)
-      modifiedSecondaryBackground: darken($(status.modified), 50)
-      addedBackground: $(status.added)
-      addedSecondaryBackground: darken($(status.added), 50)
-      deletedBackground: $(status.deleted)
-      deletedSecondaryBackground: darken($(status.deleted), 50)
+      modifiedBackground: $status.modified
+      modifiedSecondaryBackground: darken($status.modified, 50)
+      addedBackground: $status.added
+      addedSecondaryBackground: darken($status.added, 50)
+      deletedBackground: $status.deleted
+      deletedSecondaryBackground: darken($status.deleted, 50)
       # Comments and control glyphs
-      commentRangeForeground: $(std.fg.accent)
-      commentGlyphForeground: $(std.fg.accent.secondary)
-      commentUnresolvedGlyphForeground: $(std.fg.error)
-      foldingControlForeground: $(std.fg.accent)
+      commentRangeForeground: $std.fg.accent
+      commentGlyphForeground: $std.fg.accent.secondary
+      commentUnresolvedGlyphForeground: $std.fg.error
+      foldingControlForeground: $std.fg.accent
       # Misc gutter glyphs
-      itemGlyphForeground: $(std.fg.accent.secondary)
-      itemBackground: $(std.bg.panel.inner.inactive)
+      itemGlyphForeground: $std.fg.accent.secondary
+      itemBackground: $std.bg.panel.inner.inactive
     editorCommentsWidget:
-      resolvedBorder: $(std.outline.success)
-      unresolvedBorder: $(std.outline.info)
-      rangeBackground: $(std.bg.accent.faint)
-      rangeActiveBackground: $(std.bg.accent.faint.strong)
-      replyInputBackground: $(std.bg.panel.inner)
+      resolvedBorder: $std.outline.success
+      unresolvedBorder: $std.outline.info
+      rangeBackground: $std.bg.accent.faint
+      rangeActiveBackground: $std.bg.accent.faint.strong
+      replyInputBackground: $std.bg.panel.inner
 
     # Editor widget colors
     # Editor Widget (Find/Replace, Peek input, etc.)
     editorWidget:
-      foreground: $(std.fg)
-      background: $(std.bg.panel.outer)
-      border: $(std.outline.faint)
-      resizeBorder: $(std.outline)
+      foreground: $std.fg
+      background: $std.bg.panel.outer
+      border: $std.outline.faint
+      resizeBorder: $std.outline
     # Suggest Widget
     editorSuggestWidget:
-      background: $(std.bg.panel.inner)
-      border: $(std.outline.faint)
-      foreground: $(std.fg)
-      focusHighlightForeground: $(std.fg.accent.secondary)
-      highlightForeground: darken($(editorSuggestWidget.focusHighlightForeground), 25) # subtle, but visible
-      selectedForeground: $(menubar.selectionForeground)
-      selectedBackground: $(menubar.selectionBackground)
-      selectedIconForeground: $(editorSuggestWidget.selectedForeground)
+      background: $std.bg.panel.inner
+      border: $std.outline.faint
+      foreground: $std.fg
+      focusHighlightForeground: $std.fg.accent.secondary
+      highlightForeground: darken($editorSuggestWidget.focusHighlightForeground, 25) # subtle, but visible
+      selectedForeground: $menubar.selectionForeground
+      selectedBackground: $menubar.selectionBackground
+      selectedIconForeground: $editorSuggestWidget.selectedForeground
     editorSuggestWidgetStatus:
-      foreground: $(std.fg.inactive)
+      foreground: $std.fg.inactive
     # Editor Hover Widget
     editorHoverWidget:
-      foreground: $(std.fg)
-      background: $(std.bg.panel.inner)
-      border: $(std.outline.faint)
-      highlightForeground: $(std.fg.accent.secondary)
-      statusBarBackground: lighten($(editorHoverWidget.background), 25)
+      foreground: $std.fg
+      background: $std.bg.panel.inner
+      border: $std.outline.faint
+      highlightForeground: $std.fg.accent.secondary
+      statusBarBackground: lighten($editorHoverWidget.background, 25)
     # Ghost Text (Inline Suggest/Preview)
     editorGhostText:
-      foreground: $(std.fg.faint)
-      background: $(std.bg.faint)
-      border: $(transparent)
+      foreground: $std.fg.faint
+      background: $std.bg.faint
+      border: $transparent
     # Sticky Scroll
     editorStickyScroll:
-      background: $(std.bg.sticky) # soft, ambient background
-      border: $(std.outline.sticky)
-      shadow: $(std.shadow.sticky) # ambient shadow
+      background: $std.bg.sticky # soft, ambient background
+      border: $std.outline.sticky
+      shadow: $std.shadow.sticky # ambient shadow
     editorStickyScrollHover:
-      background: $(std.bg.sticky.hover) # slightly more pronounced hover background
+      background: $std.bg.sticky.hover # slightly more pronounced hover background
 
     # Debug Exception Widget
     debugExceptionWidget:
-      background: $(editorWidget.background)
-      border: $(inputValidation.errorBorder)
+      background: $editorWidget.background
+      border: $inputValidation.errorBorder
     # Marker Navigation: Base Background
     editorMarkerNavigation:
-      background: $(std.bg.panel.inner)
+      background: $std.bg.panel.inner
     # Marker Navigation: Error/Warning/Info Bars (borders)
     editorMarkerNavigationError:
-      background: $(std.bg.error)
-      headerBackground: $(std.bg.error)
+      background: $std.bg.error
+      headerBackground: $std.bg.error
     editorMarkerNavigationWarning:
-      background: $(std.bg.warning)
-      headerBackground: $(std.bg.warning)
+      background: $std.bg.warning
+      headerBackground: $std.bg.warning
     editorMarkerNavigationInfo:
-      background: $(std.bg.info)
-      headerBackground: $(std.bg.info)
+      background: $std.bg.info
+      headerBackground: $std.bg.info
     editorLink:
-      activeForeground: $(std.fg.accent.secondary)
+      activeForeground: $std.fg.accent.secondary
     editorRuler:
-      foreground: darken($(std.line.secondary), 50)
+      foreground: darken($std.line.secondary, 50)
     editorCodeLens:
-      foreground: $(std.fg.accent.secondary.faint)
+      foreground: $std.fg.accent.secondary.faint
     editorLightBulb:
-      foreground: $(colors.gold)
+      foreground: $colors.gold
     editorLightBulbAutoFix:
-      foreground: $(std.fg.info)
-
-    # sideBarSectionHeader:
-    #   foreground: $(std.fg.secondary)
-    #   background: darken($(std.bg.panel.inner), 15)
-    #   border: $(std.outline.whisper)
+      foreground: $std.fg.info
 
     # Whee! Panel stuff! YUM!
     # Panel colors
     panel:
       # Panel Base + Frame
-      background: $(std.bg.panel.inner)
-      border: $(std.outline.whisper)
-      dropBorder: $(std.bg.drop)
+      background: $std.bg.panel.inner
+      border: $std.outline.whisper
+      dropBorder: $std.bg.drop
     # Panel Title Bar
     panelTitle:
-      activeBorder: $(std.outline)
-      activeForeground: $(std.fg)
-      inactiveForeground: $(std.fg.inactive)
-      border: $(std.outline.whisper)
+      activeBorder: $std.outline
+      activeForeground: $std.fg
+      inactiveForeground: $std.fg.inactive
+      border: $std.outline.whisper
     # Panel Title Badge (eg. terminal counts)
     panelTitleBadge:
-      background: $(std.bg.badge)
-      foreground: $(std.fg.badge)
+      background: $std.bg.badge
+      foreground: $std.fg.badge
     # Panel Section Headers
     panelSectionHeader:
-      background: $(sideBarSectionHeader.background)
-      foreground: $(sideBarSectionHeader.foreground)
-      border: $(sideBarSectionHeader.border)
+      background: $sideBarSectionHeader.background
+      foreground: $sideBarSectionHeader.foreground
+      border: $sideBarSectionHeader.border
     # Panel Sections
     panelSection:
-      border: $(std.outline.whisper)
-      dropBackground: $(std.bg.drop)
+      border: $std.outline.whisper
+      dropBackground: $std.bg.drop
     #A Panel Input
     panelInput:
-      border: $(control.outline)
+      border: $control.outline
     # Panel Sticky Scroll
     panelStickyScroll:
-      background: $(std.bg.sticky)
-      border: $(std.outline.sticky)
-      shadow: $(std.shadow.sticky)
+      background: $std.bg.sticky
+      border: $std.outline.sticky
+      shadow: $std.shadow.sticky
 
     # Welcome page colors
     welcomePage:
-      background: $(std.bg.panel.innermost)
+      background: $std.bg.panel.innermost
       progress:
-        background: darken($(std.bg.success), 75)
-        foreground: $(std.fg.success)
-      tileBackground: lighten($(welcomePage.background), 35)
-      tileHoverBackground: $(std.bg.hover)
-      tileBorder: $(std.outline.whisper)
+        background: darken($std.bg.success, 75)
+        foreground: $std.fg.success
+      tileBackground: lighten($welcomePage.background, 35)
+      tileHoverBackground: $std.bg.hover
+      tileBorder: $std.outline.whisper
     # Honestly, why do we have two different cases for "t" in "walkthrough"?
     walkThrough:
-      embeddedEditorBackground: $(std.bg.panel.innermost)
+      embeddedEditorBackground: $std.bg.panel.innermost
     walkthrough:
       stepTitle:
-        foreground: $(std.fg.accent.secondary)
+        foreground: $std.fg.accent.secondary
 
     # Settings Editor colors
     settings:
-      headerForeground: $(std.fg.accent.secondary)
-      settingsHeaderHoverForeground: $(std.fg.accent) # menu on the left, and other things
-      headerBorder: $(std.outline.whisper)
-      sashBorder: $(std.outline.whisper)
-      modifiedItemIndicator: $(status.modified)
-      dropdownBackground: $(control.bg)
-      dropdownForeground: $(control.fg)
-      dropdownBorder: $(control.outline)
-      dropdownListBorder: $(control.outline)
-      checkboxBackground: $(control.bg)
-      checkboxForeground: $(control.fg)
-      checkboxBorder: $(control.outline)
+      headerForeground: $std.fg.accent.secondary
+      settingsHeaderHoverForeground: $std.fg.accent # menu on the left, and other things
+      headerBorder: $std.outline.whisper
+      sashBorder: $std.outline.whisper
+      modifiedItemIndicator: $status.modified
+      dropdownBackground: $control.bg
+      dropdownForeground: $control.fg
+      dropdownBorder: $control.outline
+      dropdownListBorder: $control.outline
+      checkboxBackground: $control.bg
+      checkboxForeground: $control.fg
+      checkboxBorder: $control.outline
       # A row is a section in a settings page.
-      rowHoverBackground: $(std.bg.hover.whisper)
-      focusedRowBackground: lighten($(std.bg.panel.innermost), 25)
-      focusedRowBorder: $(std.outline.faint)
-      textInputBackground: $(control.bg)
-      textInputForeground: $(control.fg)
-      textInputBorder: $(control.outline)
-      numberInputBackground: $(control.bg)
-      numberInputForeground: $(control.fg)
-      numberInputBorder: $(control.outline)
+      rowHoverBackground: $std.bg.hover.whisper
+      focusedRowBackground: lighten($std.bg.panel.innermost, 25)
+      focusedRowBorder: $std.outline.faint
+      textInputBackground: $control.bg
+      textInputForeground: $control.fg
+      textInputBorder: $control.outline
+      numberInputBackground: $control.bg
+      numberInputForeground: $control.fg
+      numberInputBorder: $control.outline
 
     # Output View Backgrounds
     outputView:
-      background: $(std.bg.panel.innermost)
+      background: $std.bg.panel.innermost
     outputViewStickyScroll:
-      background: $(std.bg.sticky)
+      background: $std.bg.sticky
 
     # Integrated Terminal colors
     terminal:
-      foreground: $(std.fg)
-      background: $(std.bg.panel.innermost)
+      foreground: $std.fg
+      background: $std.bg.panel.innermost
       ansiBlack: "#1e1e1e"
       ansiBlue: "#8787d7"
       ansiBrightBlack: "#252525"
@@ -758,51 +745,51 @@ theme:
       ansiRed: "#d78787"
       ansiWhite: "#d1d1d1"
       ansiYellow: "#d7c787"
-      selectionBackground: $(std.bg.accent.faint)
-      border: $(std.outline.whisper)
-      selectionForeground: $(std.fg.inverse)
-      inactiveSelectionBackground: $(std.bg.accent.whisper)
+      selectionBackground: $std.bg.accent.faint
+      border: $std.outline.whisper
+      selectionForeground: $std.fg.inverse
+      inactiveSelectionBackground: $std.bg.accent.whisper
 
-      findMatchHighlightBackground: fade($(std.highlight.bg.match), 0.7)
-      findMatchHighlightBorder: fade($(std.highlight.bg.match), 0.5)
-      findMatchBackground: fade($(std.highlight.bg.match), 0.5)
-      findMatchBorder: fade($(std.highlight.bg.match), 0.1)
+      findMatchHighlightBackground: fade($std.highlight.bg.match, 0.7)
+      findMatchHighlightBorder: fade($std.highlight.bg.match, 0.5)
+      findMatchBackground: fade($std.highlight.bg.match, 0.5)
+      findMatchBorder: fade($std.highlight.bg.match, 0.1)
       # The help for this says: "Border color of the other search matches in
       # the terminal." however, that is not true. It is in fact the colour
       # of items, like file paths, that would prompt you to open a file.
       # So it must be quite faint.
-      hoverHighlightBackground: fade($(std.bg.accent.faint), 0.5)
+      hoverHighlightBackground: fade($std.bg.accent.faint, 0.5)
 
-      initialHintForeground: $(std.fg.inactive)
-      dropBackground: $(std.bg.drop)
+      initialHintForeground: $std.fg.inactive
+      dropBackground: $std.bg.drop
       tab:
-        activeBorder: $(std.outline)
+        activeBorder: $std.outline
 
     terminalCursor:
-      foreground: $(editorCursor.foreground)
-      background: $(editorCursor.background)
+      foreground: $editorCursor.foreground
+      background: $editorCursor.background
 
     terminalCommandDecoration:
-      defaultBackground: $(std.fg)
-      successBackground: $(std.bg.success)
-      errorBackground: $(std.bg.error)
+      defaultBackground: $std.fg
+      successBackground: $std.bg.success
+      errorBackground: $std.bg.error
 
     terminalOverviewRuler:
-      cursorForeground: $(terminalCursor.foreground)
-      findMatchForeground: $(terminal.findMatchHighlightBackground)
-      border: $(std.outline.whisper)
+      cursorForeground: $terminalCursor.foreground
+      findMatchForeground: $terminal.findMatchHighlightBackground
+      border: $std.outline.whisper
 
-    # Doing this slightly differently to the rest since it's a bit lighter
-    # than the rest of the stickies.
+    # Doing this slightly differently to the rest since it's a bit lighter than
+    # the rest of the stickies.
     terminalStickyScroll:
-      background: darken($(std.bg.accent), 75)
-      border: $(std.outline.sticky)
+      background: darken($std.bg.accent, 75)
+      border: $std.outline.sticky
 
     terminalStickyScrollHover:
-      background: lighten($(terminalStickyScroll.background), 50)
+      background: lighten($terminalStickyScroll.background, 50)
 
     terminalCommandGuide:
-      foreground: $(std.fg.accent.secondary)
+      foreground: $std.fg.accent.secondary
 
     terminalSymbolIcon:
       aliasForeground: "#b0e9ff"
@@ -818,410 +805,410 @@ theme:
     # Minimap
     minimap:
       # General minimap
-      background: $(std.bg.panel.inner)
-      selectionHighlight: $(std.bg.accent.faint)
+      background: $std.bg.panel.inner
+      selectionHighlight: $std.bg.accent.faint
       # Errors & Warnings
-      errorHighlight: $(std.bg.error)
-      warningHighlight: $(std.bg.warning)
+      errorHighlight: $std.bg.error
+      warningHighlight: $std.bg.warning
 
     # Slider (scroll thumb) visuals
     minimapSlider:
-      background: $(scrollbarSlider.background)
-      hoverBackground: fade($(scrollbarSlider.hoverBackground), 0.25)
-      activeBackground: fade($(scrollbarSlider.activeBackground), 0.25)
+      background: $scrollbarSlider.background
+      hoverBackground: fade($scrollbarSlider.hoverBackground, 0.25)
+      activeBackground: fade($scrollbarSlider.activeBackground, 0.25)
 
     # Gutter decorations for git-style diff markers
     minimapGutter:
-      addedBackground: $(status.added)
-      modifiedBackground: $(status.modified)
-      deletedBackground: $(status.deleted)
+      addedBackground: $status.added
+      modifiedBackground: $status.modified
+      deletedBackground: $status.deleted
 
     # Command Center colors
     commandCenter:
       # Command Center Base
-      foreground: $(control.fg)
-      background: $(control.bg)
-      border: $(control.outline)
+      foreground: $control.outline
+      background: $control.bg
+      border: $control.outline
       # Active (hovered or clicked)
-      activeForeground: $(control.fg.active)
-      activeBackground: $(control.bg.active)
-      activeBorder: $(std.outline.faint)
+      activeForeground: $control.fg.active
+      activeBackground: $control.bg.active
+      activeBorder: $std.outline.faint
       # Inactive Window
-      inactiveForeground: lighten($(commandCenter.foreground), 15)
-      inactiveBorder: $(std.outline.faint)
+      inactiveForeground: lighten($commandCenter.foreground, 15) # the goggles, they do nothing
+      inactiveBorder: $std.outline.faint
       # Debugging State - requires debug.toolBarLocation = commandCenter
-      debuggingBackground: fade($(statusBar.debuggingBackground), 0.5)
+      debuggingBackground: fade($statusBar.debuggingBackground, 0.9)
 
     # Banner colors
     banner:
-      background: $(std.bg.warning)
-      foreground: $(std.fg.warning)
-      iconForeground: $(std.fg.warning)
+      background: $std.bg.warning
+      foreground: $std.fg.warning
+      iconForeground: $std.fg.warning
 
     # Notification Center
     notificationCenter:
-      border: $(std.outline.faint)
+      border: $std.outline.faint
     notificationCenterHeader:
-      foreground: $(std.fg.accent.secondary)
-      background: $(std.bg.panel.outer)
+      foreground: $std.fg.accent.secondary
+      background: $std.bg.panel.outer
     # Notification Toasts
     notificationToast:
-      border: $(std.outline)
+      border: $std.outline
     # Notification Items
     notifications:
-      foreground: $(std.fg)
-      background: $(std.bg.panel.inner)
-      border: $(std.outline.faint)
+      foreground: $std.fg
+      background: $std.bg.panel.inner
+      border: $std.outline.faint
     # Links inside notifications
     notificationLink:
-      foreground: $(std.fg.accent.secondary)
+      foreground: $std.fg.accent.secondary
     # Icons
     notificationsErrorIcon:
-      foreground: $(std.bg.error)
+      foreground: $std.bg.error
     notificationsWarningIcon:
-      foreground: $(std.bg.warning)
+      foreground: $std.bg.warning
     notificationsInfoIcon:
-      foreground: $(std.bg.info)
+      foreground: $std.bg.info
 
     # Extension colors
     # Extension View Prominent Button (e.g. "Install")
     extensionButton:
-      prominentForeground: $(control.fg)
-      prominentBackground: $(control.bg.secondary)
-      prominentHoverBackground: $(control.bg.secondary.hover)
+      prominentForeground: $control.fg
+      prominentBackground: $control.bg.secondary
+      prominentHoverBackground: $control.bg.secondary.hover
       # Secondary Buttons (e.g. "Enable", "Disable", etc.)
-      foreground: $(control.fg)
-      background: $(control.bg)
-      hoverBackground: $(control.bg.hover)
-      separator: $(std.line.faint)
+      foreground: $control.fg
+      background: $control.bg
+      hoverBackground: $control.bg.hover
+      separator: $std.line.faint
     # Remote Badge (for remote extensions like WSL)
     extensionBadge:
-      remoteForeground: $(std.fg.success)
-      remoteBackground: $(std.bg.success)
+      remoteForeground: $std.fg.success
+      remoteBackground: $std.bg.success
     # Icons for various metadata
     extensionIcon:
-      starForeground: $(colors.gold)
-      verifiedForeground: $(colors.green)
-      preReleaseForeground: $(colors.purple)
-      sponsorForeground: $(colors.pink)
-      privateForeground: $(colors.red)
+      starForeground: $colors.gold
+      verifiedForeground: $colors.green
+      preReleaseForeground: $colors.purple
+      sponsorForeground: $colors.pink
+      privateForeground: $colors.red
 
     # Quick picker colors
     # Quick Picker Group Labels & Borders (e.g. "recently used", "commands")
     pickerGroup:
-      foreground: $(control.fg.inverse)
-      border: $(std.outline.faint)
+      foreground: $control.fg.inverse
+      border: $std.outline.faint
     # Main Background & Foreground
     quickInput:
-      foreground: $(menu.foreground)
-      background: $(menu.background)
+      foreground: $menu.foreground
+      background: $menu.background
     # Focused Item (arrow keys / mouse hover)
     quickInputList:
-      focusForeground: $(menu.selectionForeground)
-      focusBackground: $(menu.selectionBackground)
-      focusIconForeground: $(menu.selectionForeground)
+      focusForeground: $menu.selectionForeground
+      focusBackground: $menu.selectionBackground
+      focusIconForeground: $menu.selectionForeground
     # Title Area (if visible — eg. Ctrl-O)
     quickInputTitle:
-      background: $(quickInput.background)
+      background: $quickInput.background
 
     # Text colors
     # Colors inside a text document, such as the welcome page.
     # Or markdown preview.
     textBlockQuote:
-      background: $(std.bg.accent.faint)
-      border: $(std.outline.faint)
+      background: $std.bg.accent.faint
+      border: $std.outline.faint
     textCodeBlock:
-      background: $(std.bg.accent.faint)
+      background: $std.bg.accent.faint
     textLink:
-      foreground: $(std.fg.accent.secondary)
-      activeForeground: $(std.accent.secondary)
+      foreground: $std.fg.accent.secondary
+      activeForeground: $accent.secondary
     textPreformat:
-      foreground: $(std.fg)
-      background: darken($(std.bg.accent.secondary), 25)
+      foreground: $std.fg
+      background: darken($std.bg.accent.secondary, 25)
     textSeparator:
-      foreground: $(std.fg.secondary)
+      foreground: $std.fg.secondary
 
     # Inline Edit
     inlineEdit:
       gutterIndicator:
-        primaryBorder: $(std.accent)
-        primaryForeground: $(colors.teal)
-        primaryBackground: fade($(std.accent), 0.20)
-        secondaryBorder: $(status.success)
-        secondaryForeground: $(colors.yellow)
-        secondaryBackground: fade($(std.accent), 0.07)
-        successfulBorder: $(status.success)
-        successfulForeground: $(status.success)
-        successfulBackground: fade($(std.accent), 0.13)
-        background: $(std.bg.panel.outer)
-      originalBackground: fade($(std.accent), 0.20)
-      modifiedBackground: fade($(colors.teal), 0.20)
-      originalChangedLineBackground: fade($(std.accent), 0.27)
-      originalChangedTextBackground: fade($(std.accent), 0.20)
-      modifiedChangedLineBackground: fade($(std.accent), 0.20)
-      modifiedChangedTextBackground: fade($(colors.teal), 0.27)
-      originalBorder: $(std.accent)
-      modifiedBorder: $(colors.teal)
-      tabWillAcceptModifiedBorder: $(status.success)
-      tabWillAcceptOriginalBorder: $(status.success)
+        primaryBorder: $accent
+        primaryForeground: $colors.teal
+        primaryBackground: fade($accent, 0.20)
+        secondaryBorder: $status.success
+        secondaryForeground: $colors.yellow
+        secondaryBackground: fade($accent, 0.07)
+        successfulBorder: $status.success
+        successfulForeground: $status.success
+        successfulBackground: fade($accent, 0.13)
+        background: $std.bg.panel.outer
+      originalBackground: fade($accent, 0.20)
+      modifiedBackground: fade($colors.teal, 0.20)
+      originalChangedLineBackground: fade($accent, 0.27)
+      originalChangedTextBackground: fade($accent, 0.20)
+      modifiedChangedLineBackground: fade($accent, 0.20)
+      modifiedChangedTextBackground: fade($colors.teal, 0.27)
+      originalBorder: $accent
+      modifiedBorder: $colors.teal
+      tabWillAcceptModifiedBorder: $status.success
+      tabWillAcceptOriginalBorder: $status.success
 
     # Diff editor colors
     # Diff Editor: Inserted/Removed Text
     diffEditor:
-      insertedTextBackground: fade($(status.success), 0.80)
-      insertedTextBorder: fade($(status.success), 0.80)
-      removedTextBackground: fade($(status.error), 0.80)
-      removedTextBorder: fade($(status.error), 0.80)
+      insertedTextBackground: fade($status.success, 0.80)
+      insertedTextBorder: fade($status.success, 0.80)
+      removedTextBackground: fade($status.error, 0.80)
+      removedTextBorder: fade($status.error, 0.80)
       # Diff Editor: Full Line Highlights
-      insertedLineBackground: fade($(status.success), 0.80)
-      removedLineBackground: fade($(status.error), 0.80)
+      insertedLineBackground: fade($status.success, 0.80)
+      removedLineBackground: fade($status.error, 0.80)
 
     diffEditorGutter:
-      insertedLineBackground: fade($(status.success), 0.70)
-      removedLineBackground: fade($(status.error), 0.70)
+      insertedLineBackground: fade($status.success, 0.70)
+      removedLineBackground: fade($status.error, 0.70)
 
     diffEditorOverview:
-      insertedForeground: fade($(status.success), 0.53)
-      removedForeground: fade($(status.error), 0.53)
+      insertedForeground: fade($status.success, 0.53)
+      removedForeground: fade($status.error, 0.53)
 
     # Inline Chat colors
     inlineChat:
-      background: $(std.bg.panel.outer)
-      foreground: $(std.fg)
-      border: fade($(std.accent), 0.27)
-      shadow: $(control.shadow)
+      background: $std.bg.panel.outer
+      foreground: $std.fg
+      border: fade($accent, 0.27)
+      shadow: $control.shadow
 
     inlineChatInput:
-      background: $(std.bg.panel.inner)
-      border: fade($(std.accent), 0.20)
-      focusBorder: fade($(std.accent), 0.53)
-      placeholderForeground: $(std.fg.inactive)
+      background: $std.bg.panel.inner
+      border: fade($accent, 0.20)
+      focusBorder: fade($accent, 0.53)
+      placeholderForeground: $std.fg.inactive
 
     inlineChatDiff:
-      inserted: fade($(status.success), 0.13)
-      removed: fade($(status.error), 0.13)
+      inserted: fade($status.success, 0.13)
+      removed: fade($status.error, 0.13)
 
     # Panel Chat colors
     interactive:
-      activeCodeBorder: fade($(std.accent), 0.40)
-      inactiveCodeBorder: fade($(std.accent), 0.20)
+      activeCodeBorder: fade($accent, 0.40)
+      inactiveCodeBorder: fade($accent, 0.20)
 
     # Peek view colors
     peekView:
-      border: fade($(std.accent), 0.53)
+      border: fade($accent, 0.53)
 
     peekViewTitle:
-      background: fade($(std.bg.panel.inner), 0.47)
+      background: fade($std.bg.panel.inner, 0.47)
 
     peekViewTitleLabel:
-      foreground: $(std.fg)
+      foreground: $std.fg
 
     peekViewTitleDescription:
-      foreground: $(std.fg.inactive)
+      foreground: $std.fg.inactive
 
     peekViewResult:
-      background: fade($(std.bg.panel.inner), 0.47)
-      fileForeground: $(std.fg)
-      lineForeground: $(std.fg.secondary)
-      matchHighlightBackground: $(transparent)
-      selectionBackground: $(std.bg.panel.inner)
-      selectionForeground: $(std.fg)
+      background: fade($std.bg.panel.inner, 0.47)
+      fileForeground: $std.fg
+      lineForeground: $std.fg.secondary
+      matchHighlightBackground: $transparent
+      selectionBackground: $std.bg.panel.inner
+      selectionForeground: $std.fg
 
     peekViewEditorGutter:
-      background: fade($(std.accent), 0.07)
+      background: fade($accent, 0.07)
 
     peekViewEditor:
-      matchHighlightBackground: fade($(colors.teal), 0.20)
-      matchHighlightBorder: fade($(std.accent), 0.47)
-      background: fade($(std.bg.panel.inner), 0.50)
+      matchHighlightBackground: fade($colors.teal, 0.20)
+      matchHighlightBorder: fade($accent, 0.47)
+      background: fade($std.bg.panel.inner, 0.50)
 
     peekViewEditorStickyScroll:
-      background: fade($(std.bg.panel.inner), 0.47)
+      background: fade($std.bg.panel.inner, 0.47)
 
     # Merge conflicts colors
     merge:
       # Merge Conflict: Current Content
-      currentHeaderBackground: fade($(std.accent), 0.20)
-      currentContentBackground: fade($(std.accent), 0.07)
+      currentHeaderBackground: fade($accent, 0.20)
+      currentContentBackground: fade($accent, 0.07)
       # Merge Conflict: Incoming Content
-      incomingHeaderBackground: fade($(status.success), 0.20)
-      incomingContentBackground: fade($(status.success), 0.07)
+      incomingHeaderBackground: fade($status.success, 0.20)
+      incomingContentBackground: fade($status.success, 0.07)
       # Merge Conflict: Common Ancestor
-      commonContentBackground: fade($(std.fg.secondary), 0.07)
-      commonHeaderBackground: fade($(std.fg.secondary), 0.20)
+      commonContentBackground: fade($std.fg.secondary, 0.07)
+      commonHeaderBackground: fade($std.fg.secondary, 0.20)
       # Merge Conflict: Border Line Highlight
-      border: fade($(std.accent), 0.27)
+      border: fade($accent, 0.27)
       # Merge Conflict: Unhandled Marker Highlight
 
     mergeEditor:
       change:
-        background: fade($(std.accent), 0.20)
+        background: fade($accent, 0.20)
         word:
-          background: fade($(std.accent), 0.27)
+          background: fade($accent, 0.27)
       conflict:
         unhandledUnfocused:
-          border: fade($(status.error), 0.33)
+          border: fade($status.error, 0.33)
         unhandledFocused:
-          border: fade($(status.error), 0.67)
+          border: fade($status.error, 0.67)
         handledUnfocused:
-          border: fade($(status.success), 0.33)
+          border: fade($status.success, 0.33)
         handledFocused:
-          border: fade($(status.success), 0.67)
+          border: fade($status.success, 0.67)
         handled:
-          minimapOverViewRuler: fade($(status.success), 0.67)
+          minimapOverViewRuler: fade($status.success, 0.67)
         unhandled:
-          minimapOverViewRuler: fade($(status.error), 0.67)
+          minimapOverViewRuler: fade($status.error, 0.67)
         input1:
-          background: fade($(std.accent), 0.20)
+          background: fade($accent, 0.20)
         input2:
-          background: fade($(status.success), 0.13)
+          background: fade($status.success, 0.13)
       conflictingLines:
-        background: fade($(status.error), 0.13)
+        background: fade($status.error, 0.13)
       changeBase:
-        background: fade($(std.fg.secondary), 0.13)
+        background: fade($std.fg.secondary, 0.13)
         word:
-          background: fade($(std.fg.secondary), 0.27)
+          background: fade($std.fg.secondary, 0.27)
 
     # Action Bar colors
     actionBar:
-      toggledBackground: $(std.bg.panel.inner)
+      toggledBackground: $std.bg.panel.inner
 
     simpleFindWidget:
-      sashBorder: $(test)
+      sashBorder: $test
 
     # Gauge colors
     gauge:
-      background: $(std.bg.panel.outer)
-      foreground: $(status.success)
-      border: fade($(std.accent), 0.20)
-      warningBackground: darken($(status.warning), 60)
-      warningForeground: $(colors.yellow)
-      errorBackground: darken($(status.error), 60)
-      errorForeground: $(status.error)
+      background: $std.bg.panel.outer
+      foreground: $status.success
+      border: fade($accent, 0.20)
+      warningBackground: darken($status.warning, 60)
+      warningForeground: $colors.yellow
+      errorBackground: darken($status.error, 60)
+      errorForeground: $status.error
 
     # Keybinding label colors
     keybindingLabel:
-      background: fade($(std.bg.panel.inner), 0.73)
-      foreground: $(std.fg)
-      border: fade($(std.accent), 0.33)
-      bottomBorder: fade($(std.accent), 0.47)
+      background: fade($std.bg.panel.inner, 0.73)
+      foreground: $std.fg
+      border: fade($accent, 0.33)
+      bottomBorder: fade($accent, 0.47)
 
     # Keyboard shortcut table colors
     keybindingTable:
-      headerBackground: $(std.bg.panel.outer)
-      rowsBackground: $(std.bg.panel.inner)
+      headerBackground: $std.bg.panel.outer
+      rowsBackground: $std.bg.panel.inner
 
     # Debug colors
     debugToolBar:
-      background: $(std.bg.panel.outer)
-      border: fade($(std.accent), 0.20)
+      background: $std.bg.panel.outer
+      border: fade($accent, 0.20)
 
     debugView:
-      exceptionLabelForeground: $(std.fg)
-      exceptionLabelBackground: $(status.error)
-      stateLabelForeground: $(std.bg.panel.inner)
-      stateLabelBackground: $(colors.yellow)
-      valueChangedHighlight: fade($(colors.teal), 0.40)
+      exceptionLabelForeground: $std.fg
+      exceptionLabelBackground: $status.error
+      stateLabelForeground: $std.bg.panel.inner
+      stateLabelBackground: $colors.yellow
+      valueChangedHighlight: fade($colors.teal, 0.40)
 
     debugTokenExpression:
-      name: $(std.fg)
-      value: $(colors.teal)
-      string: $(colors.pink)
-      boolean: $(status.error)
-      number: $(colors.yellow)
-      error: $(colors.pink)
-      type: fade($(std.fg.secondary), 0.67)
+      name: $std.fg
+      value: $colors.teal
+      string: $colors.pink
+      boolean: $status.error
+      number: $colors.yellow
+      error: $colors.pink
+      type: fade($std.fg.secondary, 0.67)
 
     # Testing colors
     testing:
-      runAction: $(status.success)
-      iconErrored: $(status.error)
-      iconFailed: $(status.error)
-      iconPassed: $(status.success)
-      iconQueued: $(colors.yellow)
-      iconUnset: fade($(std.fg.secondary), 0.67)
-      iconSkipped: $(colors.blue)
-      peekBorder: fade($(std.accent), 0.53)
-      peekHeaderBackground: fade($(std.bg.panel.inner), 0.47)
-      messagePeekBorder: fade($(std.accent), 0.53)
-      messagePeekHeaderBackground: fade($(std.bg.panel.inner), 0.47)
-      coveredBackground: fade($(status.success), 0.13)
-      coveredBorder: fade($(status.success), 0.53)
-      coveredGutterBackground: fade($(status.success), 0.20)
-      uncoveredBranchBackground: fade($(status.error), 0.07)
-      uncoveredBackground: fade($(status.error), 0.13)
-      uncoveredBorder: fade($(status.error), 0.53)
-      uncoveredGutterBackground: fade($(status.error), 0.20)
-      coverCountBadgeBackground: $(std.accent)
-      coverCountBadgeForeground: $(std.fg)
+      runAction: $status.success
+      iconErrored: $status.error
+      iconFailed: $status.error
+      iconPassed: $status.success
+      iconQueued: $colors.yellow
+      iconUnset: fade($std.fg.secondary, 0.67)
+      iconSkipped: $colors.blue
+      peekBorder: fade($accent, 0.53)
+      peekHeaderBackground: fade($std.bg.panel.inner, 0.47)
+      messagePeekBorder: fade($accent, 0.53)
+      messagePeekHeaderBackground: fade($std.bg.panel.inner, 0.47)
+      coveredBackground: fade($status.success, 0.13)
+      coveredBorder: fade($status.success, 0.53)
+      coveredGutterBackground: fade($status.success, 0.20)
+      uncoveredBranchBackground: fade($status.error, 0.07)
+      uncoveredBackground: fade($status.error, 0.13)
+      uncoveredBorder: fade($status.error, 0.53)
+      uncoveredGutterBackground: fade($status.error, 0.20)
+      coverCountBadgeBackground: $accent
+      coverCountBadgeForeground: $std.fg
       message:
         error:
-          lineBackground: fade($(status.error), 0.13)
-          badgeBackground: $(status.error)
-          badgeBorder: fade($(status.error), 0.53)
-          badgeForeground: $(std.bg.panel.inner)
+          lineBackground: fade($status.error, 0.13)
+          badgeBackground: $status.error
+          badgeBorder: fade($status.error, 0.53)
+          badgeForeground: $std.bg.panel.inner
         info:
-          decorationForeground: $(colors.blue)
-          lineBackground: fade($(colors.blue), 0.13)
+          decorationForeground: $colors.blue
+          lineBackground: fade($colors.blue, 0.13)
 
     # Retired testing icons (same but faded)
-    testing.iconErrored.retired: fade($(status.error), 0.40)
-    testing.iconFailed.retired: fade($(status.error), 0.40)
-    testing.iconPassed.retired: fade($(status.success), 0.40)
-    testing.iconQueued.retired: fade($(colors.yellow), 0.40)
-    testing.iconUnset.retired: fade($(std.fg.secondary), 0.33)
-    testing.iconSkipped.retired: fade($(colors.blue), 0.40)
+    testing.iconErrored.retired: fade($status.error, 0.40)
+    testing.iconFailed.retired: fade($status.error, 0.40)
+    testing.iconPassed.retired: fade($status.success, 0.40)
+    testing.iconQueued.retired: fade($colors.yellow, 0.40)
+    testing.iconUnset.retired: fade($std.fg.secondary, 0.33)
+    testing.iconSkipped.retired: fade($colors.blue, 0.40)
 
     # Debug Icons colors
     debugIcon:
-      breakpointForeground: $(status.error)
-      breakpointDisabledForeground: $(std.fg.inactive)
-      breakpointUnverifiedForeground: fade($(status.error), 0.47)
-      breakpointCurrentStackframeForeground: $(colors.gold)
-      breakpointStackframeForeground: $(status.success)
-      startForeground: $(std.accent)
-      pauseForeground: $(colors.yellow)
-      stopForeground: $(status.error)
-      disconnectForeground: $(std.fg.secondary)
-      restartForeground: $(colors.teal)
-      stepOverForeground: $(colors.blue)
-      stepIntoForeground: $(status.success)
-      stepOutForeground: $(colors.teal)
-      continueForeground: $(status.success)
-      stepBackForeground: $(colors.pink)
+      breakpointForeground: $status.error
+      breakpointDisabledForeground: $std.fg.inactive
+      breakpointUnverifiedForeground: fade($status.error, 0.47)
+      breakpointCurrentStackframeForeground: $colors.gold
+      breakpointStackframeForeground: $status.success
+      startForeground: $accent
+      pauseForeground: $colors.yellow
+      stopForeground: $status.error
+      disconnectForeground: $std.fg.secondary
+      restartForeground: $colors.teal
+      stepOverForeground: $colors.blue
+      stepIntoForeground: $status.success
+      stepOutForeground: $colors.teal
+      continueForeground: $status.success
+      stepBackForeground: $colors.pink
 
     # Debug Console colors
     debugConsole:
-      infoForeground: $(colors.teal)
-      warningForeground: $(colors.yellow)
-      errorForeground: $(status.error)
-      sourceForeground: $(std.accent)
+      infoForeground: $colors.teal
+      warningForeground: $colors.yellow
+      errorForeground: $status.error
+      sourceForeground: $accent
 
     debugConsoleInputIcon:
-      foreground: $(std.fg.secondary)
+      foreground: $std.fg.secondary
 
     # Chart colors
     charts:
-      foreground: $(std.fg)
-      lines: $(std.accent)
-      red: $(status.error)
-      blue: $(std.accent)
-      yellow: $(colors.yellow)
-      orange: $(colors.orange)
-      green: $(status.success)
-      purple: $(colors.purple)
+      foreground: $std.fg
+      lines: $accent
+      red: $status.error
+      blue: $accent
+      yellow: $colors.yellow
+      orange: $colors.orange
+      green: $status.success
+      purple: $colors.purple
 
     chart:
-      line: $(std.accent)
-      axis: fade($(std.accent), 0.33)
-      guide: fade($(std.accent), 0.20)
+      line: $accent
+      axis: fade($accent, 0.33)
+      guide: fade($accent, 0.20)
 
     # Chat colors
     chat:
-      editedFileForeground: $(colors.yellow)
-      slashCommandBackground: $(std.bg.panel.inner)
-      slashCommandForeground: $(std.accent)
+      editedFileForeground: $colors.yellow
+      slashCommandBackground: $std.bg.panel.inner
+      slashCommandForeground: $accent
 
     # Ports
     ports:
-      iconRunningProcessForeground: $(status.success)
+      iconRunningProcessForeground: $status.success

--- a/examples/advanced/import/token-colors-dark.yaml
+++ b/examples/advanced/import/token-colors-dark.yaml
@@ -1,7 +1,7 @@
 vars:
   colors:
     tc:
-      grey: oklch(0.765 0 89.9)
+      grey: oklch(0.765 0     89.9)
       green: oklch(0.679 0.092 138.1)
       blue: oklch(0.686 0.064 255.3)
       pink: oklch(0.703 0.071 332.1)

--- a/examples/advanced/import/variables.yaml
+++ b/examples/advanced/import/variables.yaml
@@ -1,9 +1,9 @@
 # Variables for later substitution
 vars:
   colors:
-    black: oklch(0.216 0 89.9)
+    black: oklch(0.176 0.003 31.1)
     white: oklch(0.923 0 89.9)
-    blue: oklch(0.553 0.079 232.4)
+    blue: oklch(0.497 0.121 257.3)
     red: oklch(0.672 0.215 25.1)
     yellow: oklch(0.921 0.148 98.1)
     orange: oklch(0.721 0.134 71.2)
@@ -11,148 +11,150 @@ vars:
     green2: oklch(0.767 0.177 136.6)
     purple: oklch(0.641 0.21 327.7)
     pink: oklch(0.809 0.146 340.6)
-    teal: oklch(0.503 0.058 231.3)
-    teal2: oklch(0.905 0.153 192.8)
-    gold: oklch(0.86 0.168 87.8)
+    teal: oklch(0.431 0.049 231.1)
+    gold: oklch(0.86  0.168 87.8)
 
   # The following define secondary basics that can be relied upon by the
   # theme's definition.
   std:
-    fg.hover: $(std.fg)
-    fg.inverse: invert($(std.fg))
-    fg.secondary: darken($(std.fg), 5)
-    fg.inactive: darken($(std.fg), 25)
-    fg.faint: fade($(std.fg), 0.50)
-    fg.accent: lighten($(std.accent), 50)
-    fg.accent.faint: fade(lighten($(std.accent), 30), 0.50)
-    fg.accent.whisper: fade($(std.fg.accent.faint), 0.30)
-    fg.accent.secondary: lighten($(std.accent.secondary), 50)
-    fg.accent.secondary.faint: fade(lighten($(std.accent.secondary), 30), 0.50)
-    fg.success: $(std.fg)
-    fg.warning: $(std.fg)
-    fg.info: lighten($(status.info), 25)
-    fg.error: lighten($(status.error), 70)
-    fg.badge: $(std.bg)
+    fg: $theme.fg
+    fg.hover: $theme.fg
+    fg.inverse: $std.bg
+    fg.secondary: darken($std.fg, 5)
+    fg.inactive: darken($std.fg, 25)
+    fg.faint: fade($std.fg, 0.50)
+    fg.accent: lighten($accent, 50)
+    fg.accent.faint: fade(lighten($accent, 30), 0.50)
+    fg.accent.whisper: fade($std.fg.accent.faint, 0.30)
+    fg.accent.secondary: lighten($accent.secondary, 50)
+    fg.accent.secondary.faint: fade(lighten($std.fg.accent.secondary, 30), 0.50)
+    fg.success: $std.fg
+    fg.warning: $std.fg
+    fg.info: lighten($status.info, 25)
+    fg.error: lighten($status.error, 70)
+    fg.badge: $std.bg
 
-    bg: $(std.bg)
-    bg.inverse: invert($(std.bg))
-    bg.faint: fade($(std.bg.accent), 0.40)
-    bg.inactive: darken($(std.bg), 15)
-    bg.accent: darken($(accent), 15)
-    bg.badge: $(std.bg.accent.secondary)
-    bg.accent.faint: fade($(accent), 0.40)
-    bg.accent.faint.strong: fade($(std.bg.accent.faint), 0.50)
-    bg.accent.whisper: fade($(std.bg.accent.faint), 0.80)
-    bg.accent.strong: darken($(accent), 25)
-    bg.accent.secondary: lighten($(std.accent.secondary), 25)
-    bg.hover: darken($(std.bg.accent), 15)
-    bg.hover.faint: fade($(std.bg.hover), 0.25)
-    bg.hover.whisper: fade($(std.bg.hover.faint), 0.5)
-    bg.success: $(status.success)
-    bg.warning: $(status.warning)
-    bg.info: $(status.info)
-    bg.error: $(status.error)
-    bg.drop: fade($(std.accent), 0.75)
-    bg.sticky: fade($(std.bg), 0.10)
-    bg.sticky.hover: fade($(std.bg.accent.faint), 0.45)
+    bg: $theme.bg
+    bg.inverse: invert($std.bg)
+    bg.faint: fade($std.bg.accent, 0.40)
+    bg.inactive: darken($std.bg, 15)
+    bg.accent: darken($accent, 15)
+    bg.badge: $std.bg.accent.secondary
+    bg.accent.faint: fade($accent, 0.40)
+    bg.accent.faint.strong: fade($std.bg.accent.faint, 0.50)
+    bg.accent.whisper: fade($std.bg.accent.faint, 0.80)
+    bg.accent.strong: darken($accent, 25)
+    bg.accent.secondary: lighten($accent.secondary, 25)
+    bg.hover: darken($std.bg.accent, 15)
+    bg.hover.faint: fade($std.bg.hover, 0.25)
+    bg.hover.whisper: fade($std.bg.hover.faint, 0.5)
+    bg.success: $status.success
+    bg.warning: $status.warning
+    bg.info: $status.info
+    bg.error: $status.error
+    bg.drop: fade($accent, 0.75)
+    bg.sticky: fade($std.bg, 0.10)
+    bg.sticky.hover: fade($std.bg.accent.faint, 0.45)
 
-    bg.panel.outer: $(std.bg)
-    bg.panel.outer.inactive: $(std.bg.inactive)
-    bg.panel.inner: lighten($(std.bg.panel.outer), 10)
-    bg.panel.inner.inactive: lighten($(std.bg.panel.outer.inactive), 10)
-    bg.panel.innermost: lighten($(std.bg.panel.inner), 10)
-    bg.panel.innermost.inactive: fade($(std.bg.panel.inner.inactive), 0.25)
+    bg.panel.outer: $std.bg
+    bg.panel.outer.inactive: $std.bg.inactive
+    bg.panel.inner: lighten($std.bg.panel.outer, 10)
+    bg.panel.inner.inactive: lighten($std.bg.panel.outer.inactive, 10)
+    bg.panel.innermost: lighten($std.bg.panel.inner, 10)
+    bg.panel.innermost.inactive: fade($std.bg.panel.inner.inactive, 0.25)
 
     highlight:
       fg:
-        accent: invert($(std.highlight.bg.accent))
-        read: invert($(std.highlight.bg.read))
-        write: invert($(std.highlight.bg.write))
-        delete: invert($(std.highlight.bg.delete))
-        rename: invert($(std.highlight.bg.rename))
-        match: $(transparent)
+        accent: invert($std.highlight.bg.accent)
+        read: invert($std.highlight.bg.read)
+        write: invert($std.highlight.bg.write)
+        delete: invert($std.highlight.bg.delete)
+        rename: invert($std.highlight.bg.rename)
+        match: $transparent
       bg:
-        accent: alpha($(std.bg.accent), 0.25)
-        read: alpha($(colors.green), 0.25)
-        write: alpha($(colors.orange), 0.25)
-        delete: alpha($(colors.red), 0.25)
-        rename: alpha($(colors.purple), 0.25)
-        match: $(colors.green2)
+        accent: alpha($std.bg.accent, 0.25)
+        read: alpha($colors.green, 0.25)
+        write: alpha($colors.orange, 0.25)
+        delete: alpha($colors.red, 0.25)
+        rename: alpha($colors.purple, 0.25)
+        match: $colors.green2
 
-    outline: darken($(std.line), 15)
-    outline.strong: $(std.line.strong)
-    outline.hover: $(std.line.strong)
-    outline.faint: $(std.line.faint)
-    outline.whisper: $(std.line.whisper)
-    outline.faint.strong: $(std.line.faint.strong)
-    outline.secondary: $(std.line.secondary)
-    outline.success: fade(lighten($(status.success), 25), 0.40)
-    outline.error: fade(lighten($(status.error), 25), 0.40)
-    outline.warning: fade(lighten($(status.warning), 25), 0.40)
-    outline.info: fade(lighten($(status.info), 25), 0.40)
-    outline.sticky: $(transparent)
+    outline: darken($std.line, 15)
+    outline.strong: $std.line.strong
+    outline.hover: $std.line.strong
+    outline.faint: $std.line.faint
+    outline.whisper: $std.line.whisper
+    outline.faint.strong: $std.line.faint.strong
+    outline.secondary: $std.line.secondary
+    outline.success: fade(lighten($status.success, 25), 0.40)
+    outline.error: fade(lighten($status.error, 25), 0.40)
+    outline.warning: fade(lighten($status.warning, 25), 0.40)
+    outline.info: fade(lighten($status.info, 25), 0.40)
+    outline.sticky: $transparent
 
-    line: $(std.accent)
-    line.strong: lighten($(std.line), 25)
-    line.faint: fade($(std.line), 0.50)
-    line.faint.strong: lighten($(std.line.faint), 25)
-    line.whisper: fade($(std.line.faint), 0.65)
-    line.secondary: $(std.accent.secondary)
+    line: $accent
+    line.strong: lighten($std.line, 25)
+    line.faint: fade($std.line, 0.50)
+    line.faint.strong: lighten($std.line.faint, 25)
+    line.whisper: fade($std.line.faint, 0.65)
+    line.secondary: $accent.secondary
 
-    shadow.sticky: fade($(std.shadow), 0.25)
+    shadow.sticky: fade($shadow, 0.25)
 
   status:
-    warning: $(colors.orange)
-    info: $(colors.teal)
-    error: $(colors.red)
-    success: $(colors.green)
+    warning: $colors.orange
+    info: $colors.teal
+    error: $colors.red
+    success: $colors.green
 
-    added: lighten($(status.success), 20)
-    modified: lighten($(status.warning), 20)
-    deleted: lighten($(status.error), 20)
-    ignored: darken($(main), 50)
+    added: lighten($status.success, 20)
+    modified: lighten($status.warning, 20)
+    deleted: lighten($status.error, 20)
+    ignored: darken($main, 50)
 
   ops:
-    read: $(colors.green)
-    write: $(colors.blue)
-    delete: $(colors.red)
-    rename: $(colors.purple)
+    read: $colors.green
+    write: $colors.blue
+    delete: $colors.red
+    rename: $colors.purple
 
-  accent: $(std.accent)
+  accent: $theme.accent
+  accent.secondary: $theme.accentSecondary
   transparent: "#00000000"
+  shadow: $theme.shadow
 
   control:
-    base: darken($(std.accent), 25)
+    base: darken($accent, 25)
 
-    bg: fade($(control.base), 0.50)
-    bg.secondary: darken($(control.bg), 10)
-    bg.hover: $(std.bg.accent)
-    bg.active: darken($(control.bg), 25)
-    bg.secondary.hover: darken($(control.bg.secondary), 25)
+    fg: $colors.white
+    fg.inverse: invert($control.fg)
+    fg.secondary: $control.fg
+    fg.secondary.hover: $control.fg
+    fg.hover: $std.fg.hover
+    fg.active: $std.fg.accent.secondary
 
-    fg: $(std.fg)
-    fg.inverse: invert($(control.fg))
-    fg.secondary: $(control.fg)
-    fg.secondary.hover: $(control.fg)
-    fg.hover: $(std.fg.hover)
-    fg.active: $(std.fg.accent.secondary)
+    bg: fade($control.base, 0.50)
+    bg.secondary: darken($control.bg, 10)
+    bg.hover: $std.bg.accent
+    bg.active: darken($control.bg, 25)
+    bg.secondary.hover: darken($control.bg.secondary, 25)
 
-    outline: $(std.outline)
-    outline.active: lighten($(std.outline), 50)
-    outline.focus: lighten($(control.outline), 50)
+    outline: $std.outline
+    outline.active: lighten($std.outline, 50)
+    outline.focus: lighten($control.outline, 50)
 
-    shadow: fade($(std.shadow), 0.1)
+    shadow: fade($shadow, 0.1)
 
   # Used for various level-related things.
   level:
-    - $(colors.orange)
-    - $(colors.yellow)
-    - $(colors.green)
-    - $(colors.teal)
-    - $(colors.blue)
-    - $(colors.purple)
-    - $(colors.pink)
-    - $(colors.red)
+    - $colors.orange
+    - $colors.yellow
+    - $colors.green
+    - $colors.teal
+    - $colors.blue
+    - $colors.purple
+    - $colors.pink
+    - $colors.red
 
   # Use this to find stupid elements that cannot be found.
   test: "#ff0000ee"

--- a/examples/advanced/src/blackboard.yaml
+++ b/examples/advanced/src/blackboard.yaml
@@ -1,32 +1,30 @@
 # Theme Config
 config:
-  $schema: vscode://schemas/color-theme
+  schema: vscode://schemas/color-theme
   name: blackboard
   type: dark
 
   import:
-    global:
-      - ../import/variables.yaml
-    colors:
-      - ../import/colors.yaml
-    tokenColors:
-      - ../import/token-colors-$(type).yaml
+    global: ../import/variables.yaml
+    colors: ../import/colors.yaml
+    tokenColors: ../import/token-colors-$(type).yaml
 
   custom:
     semanticHighlighting: true
     colorSpaceName: sRGB
 
 vars:
-  main: $(colors.white)
+  main: $colors.white
   inverse: invert($main)
 
-  std:
-    # The following define primary basics that can be relied upon by the
-    # variables definitions. Dark and light themes will define these
-    # differently. Anything expressed here will override anything being
-    # imported.
-    fg: $(main)
-    bg: $(inverse)
-    accent: $(colors.blue)
-    accent.secondary: $(colors.teal)
-    shadow: alpha($(std.accent), 0.25)
+  # The following define primary basics that can be relied upon by the
+  # variables definitions. Dark and light themes will define these
+  # differently. Anything expressed here will override anything being
+  # imported.
+
+  theme:
+    fg: $main
+    bg: $colors.black
+    accent: $colors.blue
+    accentSecondary: $colors.teal
+    shadow: alpha($theme.accent, 0.25)

--- a/examples/advanced/src/bubblegum-goth.yaml
+++ b/examples/advanced/src/bubblegum-goth.yaml
@@ -5,28 +5,28 @@ config:
   type: dark
 
   import:
-    global:
-      - ../import/variables.yaml
-    colors:
-      - ../import/colors.yaml
-    tokenColors:
-      - ../import/token-colors-$(type).yaml
+    global: ../import/variables.yaml
+    colors: ../import/colors.yaml
+    tokenColors: ../import/token-colors-${type}.yaml
 
   custom:
     semanticHighlighting: true
     colorSpaceName: sRGB
 
 vars:
-  main: $(colors.white)
-  inverse: invert($(main))
+  main: $colors.white
+  inverse: invert($main)
 
-  std:
-    # The following define primary basics that can be relied upon by the
-    # variables definitions. Dark and light themes will define these
-    # differently. Anything expressed here will override anything being
-    # imported.
-    fg: $(main)
-    bg: $(inverse)
-    accent: $(colors.pink)
-    accent.secondary: darken($(colors.pink), 60)
-    shadow: alpha($(std.accent), 0.25)
+  # The following define primary basics that can be relied upon by the
+  # variables definitions. Dark and light themes will define these
+  # differently. Anything expressed here will override anything being
+  # imported.
+  fg:
+    main: $main
+
+  theme:
+    fg: $main
+    bg: $colors.black
+    accent: $colors.pink
+    accentSecondary: darken($colors.pink, 60)
+    shadow: alpha($theme.accent, 0.25)

--- a/examples/advanced/src/corporate.yaml
+++ b/examples/advanced/src/corporate.yaml
@@ -1,6 +1,6 @@
 # Theme Config
 config:
-  $schema: vscode://schemas/color-theme
+  schema: vscode://schemas/color-theme
   name: corporate
   type: dark
 
@@ -10,25 +10,27 @@ config:
     colors:
       - ../import/colors.yaml
     tokenColors:
-      - ../import/token-colors-$(type).yaml
+      - ../import/token-colors-${type}.yaml
 
   custom:
     semanticHighlighting: true
     colorSpaceName: sRGB
 
 vars:
-  white: oklch(0.92 0 0)
-  black: oklch(0.27 0.03 256)
-  main: $(colors.white)
-  inverse: invert($(main))
+  main: $colors.white
+  inverse:
+    invert($main)
 
-  std:
     # The following define primary basics that can be relied upon by the
     # variables definitions. Dark and light themes will define these
     # differently. Anything expressed here will override anything being
     # imported.
-    fg: $(main)
-    bg: $(inverse)
-    accent: fade($(colors.teal2), 0.25)
-    accent.secondary: $(colors.blue)
-    shadow: alpha($(std.accent), 0.25)
+  fg:
+    main: $main
+
+  theme:
+    fg: $main
+    bg: lighten($colors.black, 20)
+    accent: $colors.teal
+    accentSecondary: lighten($colors.blue, 15)
+    shadow: alpha($accent, 0.25)

--- a/src/components/ThemeToken.js
+++ b/src/components/ThemeToken.js
@@ -29,6 +29,7 @@ export default class ThemeToken {
   #dependency = null
   #parentTokenKey = null
   #trail = new Array()
+  #parsedColor = null
 
   /**
    * Constructs a ThemeToken with a given token name.
@@ -221,6 +222,26 @@ export default class ThemeToken {
   }
 
   /**
+   * Sets the parsed color object for this token.
+   *
+   * @param {object} parsedColor - The parsed Culori color object
+   * @returns {ThemeToken} This token instance.
+   */
+  setParsedColor(parsedColor) {
+    this.#parsedColor = parsedColor
+    return this
+  }
+
+  /**
+   * Gets the parsed color object of this token.
+   *
+   * @returns {object|null} The parsed Culori color object or null.
+   */
+  getParsedColor() {
+    return this.#parsedColor
+  }
+
+  /**
    * Checks if this token has an ancestor with the given token name.
    *
    * @param {string} name - The name of the ancestor token to check for.
@@ -237,5 +258,23 @@ export default class ThemeToken {
    */
   getPool() {
     return this.#pool
+  }
+
+  /**
+   * Returns a JSON representation of the ThemeToken.
+   *
+   * @returns {object} JSON representation of the ThemeToken
+   */
+  toJSON() {
+    return {
+      name: this.#name,
+      kind: this.#kind,
+      rawValue: this.#rawValue,
+      value: this.#value,
+      dependency: this.#dependency?.toJSON() ?? null,
+      parentTokenKey: this.#parentTokenKey,
+      trail: this.#trail,
+      parsedColor: this.#parsedColor
+    }
   }
 }


### PR DESCRIPTION
# Variable Syntax Modernization and Color Handling Improvements

This PR updates the variable syntax throughout the theme system, replacing the older `$(var)` syntax with the more modern `$var` syntax. This change makes the theme files cleaner and more readable.

Additionally, the PR enhances color handling in several ways:

- Improved the color space preservation when using color functions like `lighten()` and `darken()`
- Added support for tracking parsed color information in tokens for more accurate color transformations
- Restructured theme variable organization for better clarity and consistency
- Enhanced the token resolution visualization in the CLI with a clearer hierarchical display

The PR also includes updates to example theme files to use the new syntax and reorganizes some variable definitions to follow a more logical structure. File paths in the launch configurations have been updated to match the current naming conventions.

These changes will make theme development more intuitive while ensuring color transformations maintain their intended appearance across different color spaces.