### PR TITLE
Add entity.name.class to Plain Text scope and enhance resolve command with color lookup options

### DIFF
--- a/examples/advanced/import/token-colors-dark.yaml
+++ b/examples/advanced/import/token-colors-dark.yaml
@@ -143,7 +143,7 @@ theme:
     # #########################################################################
 
     - name: Plain Text
-      scope: meta.paragraph, text.html, meta.jsx.children, doctype
+      scope: meta.paragraph, text.html, meta.jsx.children, doctype, entity.name.class
       settings:
         foreground: $scope.baseText
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gesslar/aunty",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "displayName": "Aunty Rose",
   "description": "Make gorgeous themes that speak as boldly as you do.",
   "publisher": "gesslar",


### PR DESCRIPTION
# Enhanced Theme Resolution Commands for Scope-Based Lookups

This PR adds more granular resolution commands to the CLI, allowing users to look up specific theme elements:

- Added `--color` option to resolve color variables to their final values
- Added `--tokenColor` option to resolve tokenColors scopes (e.g., `entity.name.class`)
- Added `--semanticTokenColor` option to resolve semanticTokenColors scopes

The existing `--token` option has been replaced with these more specific commands to provide clearer, more targeted resolution capabilities.

Additionally, the PR adds support for disambiguating multiple matching scopes by allowing users to append an index (e.g., `entity.name.class.1`) when multiple definitions exist for the same scope.

As part of this change, `entity.name.class` has been added to the Plain Text scope in the dark theme example.