### PR TITLE
Add copyErrorStack method and improve stack trace handling in AuntyError

### DIFF
--- a/CODE_FORMATTING_RULES.md
+++ b/CODE_FORMATTING_RULES.md
@@ -1,0 +1,50 @@
+# Dear robot PR reviewer in the cloud
+
+Please to be _not_ suggesting anything like the following:
+
+**GitHub Copilot:**
+
+> [nitpick] Missing space after if keyword. Should be `if (!this.#errorStack && error.stack)`
+to follow standard JavaScript formatting conventions.
+
+GitHub, Prettier is the devil (no offense to Prettier) and its rigid,
+uglification code style rules can eat a bag of uhhh ... fries. 👀
+
+I code with intent and spacing is _specific_ to my style, as is how things are
+laid out, and paragraphed, stanza'ed, etc. Best to be just sticking to code
+reviews that affect, well, the application.
+
+I have very specific rules for linting found in eslint.config.js, which suits
+me and my style just fine without some freakish, space-fetishist Prettier
+dominating and actually ruining my carefully designed and structured code.
+
+Worst thing ever. Opinionated formatter; I'll show you an opinionated
+formatter.
+
+**Claude code:**
+
+Potential Issues & Improvements
+
+> Code Style Consistency
+> Missing space after if (line 74): `if(!this.#errorStack` should be `if (!this.#errorStack` to match project style
+
+Claude, when you say something like "to match the project style," it reduces my
+confidence in your ability to review when the linting rules are clearly
+articulated in the file eslint.config.js. As you can see, this file is
+_comprehensive_. It is purposeful and aligns with my coding style. Please.
+
+## In conclusion
+
+If you scour a PR and find nothing to bemoan, it's _all right to say that
+you didn't find anything to pick at *tech-wise*_.
+
+This isn't an annual budget where if you don't find _something_ to spend your
+money/criticism on, then you lose it next time. It's okay to not see any
+faults. It's also okay for me to open up a review and see "Oh wow, I got it
+right this time!"
+
+Well, this time wasn't this time. 😭
+
+## P.S
+
+Maybe next time.

--- a/src/components/AuntyError.js
+++ b/src/components/AuntyError.js
@@ -116,7 +116,7 @@ export default class AuntyError extends Error {
           ...rest
             .split("\n")
             .map(line => {
-              const {at} = line.match(/^\s{4}at\s(?<at>.*)$/)?.groups ?? {}
+              const {at} = line.match(/^\s{4}at\s(?<at>.*)$/)?.groups?.at ?? {}
               return at
                 ? `* ${at}`
                 : line

--- a/src/components/AuntyError.js
+++ b/src/components/AuntyError.js
@@ -116,7 +116,7 @@ export default class AuntyError extends Error {
           ...rest
             .split("\n")
             .map(line => {
-              const {at} = line.match(/^\s{4}at\s(?<at>.*)$/)?.groups?.at ?? {}
+              const at = line.match(/^\s{4}at\s(?<at>.*)$/)?.groups?.at ?? {}
               return at
                 ? `* ${at}`
                 : line

--- a/src/components/AuntyError.js
+++ b/src/components/AuntyError.js
@@ -81,7 +81,7 @@ export default class AuntyError extends Error {
    * Reports the error to the terminal with formatted output.
    * Optionally includes detailed stack trace information.
    *
-   * @param {boolean?} [nerdMode] - Whether to include detailed stack trace
+   * @param {boolean} [nerdMode] - Whether to include detailed stack trace
    */
   report(nerdMode=false) {
     Term.error(


### PR DESCRIPTION
# Enhanced Error Handling with Stack Trace Preservation

This PR improves the `AuntyError` class by adding the ability to preserve and display the original error's stack trace when converting other errors to `AuntyError` instances.

Key changes:
- Added a new `#errorStack` private property to store the original error's stack trace
- Implemented a `copyErrorStack()` method to capture stack information from source errors
- Updated the `from()` static method to preserve the original error's stack trace
- Enhanced stack trace formatting in `#fullBodyMassage()` to include both the AuntyError stack and the original error stack
- Improved JSDoc parameter documentation with optional parameter notation

These changes provide more comprehensive error reporting by maintaining the full context of where errors originated, making debugging easier and more effective.