### PR TITLE
Add test script and bump version to 0.16.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gesslar/aunty",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "displayName": "Aunty Rose",
   "description": "Make gorgeous themes that speak as boldly as you do.",
   "publisher": "gesslar",
@@ -18,7 +18,8 @@
     "exec": "node ./src/cli.js",
     "lint": "eslint src/",
     "submit": "npm publish --access public",
-    "examples": "node ./examples/validator.js"
+    "examples": "node ./examples/validator.js",
+    "test": "echo 1, 2, 3."
   },
   "engines": {
     "node": ">=20.0.0"


### PR DESCRIPTION
Bump version to 0.16.0 and add test script

This PR updates the package version from 0.15.0 to 0.16.0 and adds a simple test script that outputs "1, 2, 3." when executed with `npm test`.