### PR TITLE
Update test script to read from TESTING.txt file

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "lint": "eslint src/",
     "submit": "npm publish --access public",
     "examples": "node ./examples/validator.js",
-    "test": "echo 1, 2, 3."
+    "test": "node -p \"require('fs').readFileSync('TESTING.txt', 'utf8')\""
   },
   "engines": {
     "node": ">=20.0.0"


### PR DESCRIPTION
Updated the `test` script in package.json to read and print the contents of TESTING.txt instead of echoing "1, 2, 3." This change improves the testing process by using actual test content from a dedicated file.