### PR TITLE
Add await to recordBuildFail event emissions

### DIFF
--- a/src/components/Session.js
+++ b/src/components/Session.js
@@ -184,7 +184,7 @@ export default class AuntySession {
 
     } catch(error) {
       // Track failed build
-      this.#command.asyncEmit("recordBuildFail", this.#theme)
+      await this.#command.asyncEmit("recordBuildFail", this.#theme)
       this.#history.push({
         timestamp: buildStart,
         loadTime: loadCost || 0,
@@ -297,7 +297,7 @@ export default class AuntySession {
       this.#command.asyncEmit("building")
       await this.#buildPipeline(true)
     } catch(error) {
-      this.#command.asyncEmit("recordBuildFail", this.#theme)
+      await this.#command.asyncEmit("recordBuildFail", this.#theme)
       throw AuntyError.new("Handling rebuild request.", error)
     } finally {
       this.#building = false


### PR DESCRIPTION
Fixed asynchronous event handling in AuntySession by adding missing `await` keywords to `asyncEmit("recordBuildFail")` calls. This ensures proper completion of the build failure recording process before continuing execution.