### PR TITLE
Add VSCode launch config for corporate lint with nerd mode and fix error logging

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -165,6 +165,22 @@
       "console": "integratedTerminal"
     },
     {
+      "name": "Advanced (Corporate) (lint) (nerd)",
+      "type": "node",
+      "request": "launch",
+      "runtimeExecutable": "npm",
+      "runtimeArgs": [
+        "run-script",
+        "exec",
+        "--",
+        "lint",
+        "--nerd",
+        "./examples/advanced/src/corporate.yaml",
+      ],
+      "cwd": "${workspaceFolder}",
+      "console": "integratedTerminal"
+    },
+    {
       "name": "Advanced (Corporate) (build)",
       "type": "node",
       "request": "launch",

--- a/src/AuntyCommand.js
+++ b/src/AuntyCommand.js
@@ -118,7 +118,7 @@ export default class AuntyCommand {
       try {
         await this.execute(...arg)
       } catch(error) {
-        throw AuntyError.new(`Trying to execute ${this.constructor.name} with ${arg}`, error)
+        throw AuntyError.new(`Trying to execute ${this.constructor.name} with ${JSON.stringify(...arg)}`, error)
       }
     })
 


### PR DESCRIPTION
Added a new VS Code launch configuration for linting the corporate example with nerd mode and improved error reporting in AuntyCommand.

The PR adds a new "Advanced (Corporate) (lint) (nerd)" launch configuration to VS Code, allowing developers to easily run the linter with the nerd flag on the corporate example.

Additionally, it enhances error reporting in the AuntyCommand class by properly stringifying arguments in error messages, making debugging failed command executions more informative.